### PR TITLE
switch to alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu
-RUN apt update
-RUN apt install -y python python-pip python-dev openssl libffi-dev musl-dev make gcc git curl librtmp* libxml2-dev libxslt-dev
+FROM python:2.7-alpine
+RUN apk --update add --virtual build-dependencies git gcc musl-dev libffi-dev libxml2-dev libxslt-dev openssl-dev make
 WORKDIR /usr/src/owaspnettacker
-RUN git clone https://github.com/zdresearch/OWASP-Nettacker.git .
-RUN pip install -r requirements.txt
-CMD [ "python", "./nettacker.py" ]
+RUN git clone --depth 1 https://github.com/zdresearch/OWASP-Nettacker.git . && \
+    pip install --no-cache-dir -r requirements.txt && \
+    apk del build-dependencies && rm -rf /var/cache/apk/*
+ENTRYPOINT ["python", "./nettacker.py"]
+CMD [ "--help" ]


### PR DESCRIPTION
#### Checklist
- [x ] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [ ] I have added the relevant documentation. (I don't have access to modify it)
- [x ] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
- I have switched to alpine instead of using ubuntu image.
- Added some enhancements like removing the development packages after finishing the installation.
- Used combination of `ENTRYPOINT` and `CMD` so it will be easier to run commands by passing the arguments directly like below instead of typing the whole command:
```
docker run -it --rm owasp-nettacker:latest -i 127.0.0.1 --profile information_gathering
```
- This PR closes #188 

- I have tried to use python 3.7 image which is `python:alpine` but the project dependencies do not support it. for example py3DNS library gives the following:
```
Collecting py3DNS==3.1.1a0 (from -r requirements.txt (line 16))
  Downloading https://files.pythonhosted.org/packages/8e/a3/b8cae77d27ac818390f864583e881ee7d332e2450391ddf1b52dcaaeb521/py3dns-3.1.1a.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-j64ha9ot/py3DNS/setup.py", line 7, in <module>
        import DNS
      File "/tmp/pip-install-j64ha9ot/py3DNS/DNS/__init__.py", line 27, in <module>
        from .Base import DnsRequest
      File "/tmp/pip-install-j64ha9ot/py3DNS/DNS/Base.py", line 96
        self.async=None
                 ^
    SyntaxError: invalid syntax
```
Should I go with different python version like 3.6 for example ? Let me know so i can test it.

#### Your development environment
- OS: `Linux`
- Python Version: `2.7`