### PR TITLE
Added all possible conditions to http_cors module

### DIFF
--- a/lib/vuln/http_cors/engine.py
+++ b/lib/vuln/http_cors/engine.py
@@ -143,10 +143,8 @@ def http_cors(target, port, timeout_sec, log_in_file, language, time_sleep,
             if req.headers['Access-Control-Allow-Origin'].startswith("https://"):
                 print("http-origin allowed CORS misconfiguration found")
                 return True
-            
             else:
                 return False
-
 
     except Exception as e:
         # some error warning

--- a/lib/vuln/http_cors/engine.py
+++ b/lib/vuln/http_cors/engine.py
@@ -85,7 +85,7 @@ def http_cors(target, port, timeout_sec, log_in_file, language, time_sleep,
                 'null-origin': 'null',
                 'broken parser': '%60.example.com',
                 'unescaped regex': root.replace('.', 'x', 1),
-                'http-origin allowed': 'https://' + urlparsed.netloc,
+                'http-origin allowed': 'http://' + urlparsed.netloc,
             }
             time.sleep(0.01)
             headers = {'Referer': 'http://example.foo/CORSexample1.html', 'Origin': origin["wildcard value"],
@@ -140,7 +140,7 @@ def http_cors(target, port, timeout_sec, log_in_file, language, time_sleep,
             headers = {'Referer': 'http://example.foo/CORSexample1.html', 'Origin': origin["http-origin allowed"],
                        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:24.0) Gecko/20100101 Firefox/24.0'}
             req = requests.head(target, timeout=10, headers=headers)
-            if req.headers['Access-Control-Allow-Origin'].startswith("https://"):
+            if req.headers['Access-Control-Allow-Origin'].startswith("http://"):
                 print("http-origin allowed CORS misconfiguration found")
                 return True
             else:

--- a/lib/vuln/http_cors/engine.py
+++ b/lib/vuln/http_cors/engine.py
@@ -23,10 +23,8 @@ from lib.socks_resolver.engine import getaddrinfo
 from core._time import now
 from core.log import __log_into_file
 import requests
-from urlparse import urlparse, parse_qs
+from urlparse import urlparse
 import tldextract
-import time
-
 
 def extra_requirements_dict():
     return {
@@ -78,7 +76,7 @@ def http_cors(target, port, timeout_sec, log_in_file, language, time_sleep,
             domainName =  tldextract.extract(target)
             root = domainName.domain + domainName.suffix
             origin = {
-                'wildcard value': '*', 
+                'wildcard value': '*',
                 'origin reflected': scheme + 'example.com',
                 'post-domain wildcard': root + '.example.com',
                 'pre-domain wildcard': 'example.com.' + root,

--- a/lib/vuln/http_cors/engine.py
+++ b/lib/vuln/http_cors/engine.py
@@ -75,6 +75,8 @@ def http_cors(target, port, timeout_sec, log_in_file, language, time_sleep,
             req = requests.get(target, headers=headers)
             if req.headers['Access-Control-Allow-Origin'] == "*":
                 return True
+            elif req.headers['Access-Control-Allow-Origin'] == "http://example.foo" and req.headers['Access-Control-Allow-Credentials'] == "true":
+                return True
             else:
                 return False
 


### PR DESCRIPTION
CORS misconfiguration is not only about seeing Access-Control-Allow-Origin: * response header but also Access-Control-Allow-Origin: http://example.foo\r\nAccess-Control-Allow-Credentials: True. If these headers are present that for sure the website is vulnerable to cors.

#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [X] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request

#### Your development environment
- OS: `Linux`
- OS Version: `Ubuntu`
- Python Version: `3.6.9`