### PR TITLE
Remove external ip leak from reports

### DIFF
--- a/lib/html_log/_log_data.py
+++ b/lib/html_log/_log_data.py
@@ -21,7 +21,7 @@ table {
 }
 
 th {
-    background: url(https://jackrugile.com/images/misc/noise-diagonal.png), linear-gradient(#777, #444);
+    background: linear-gradient(#777, #444);
     border-left: 1px solid #555;
     border-right: 1px solid #777;
     border-top: 1px solid #555;


### PR DESCRIPTION
Every report generated contains an external asset (css image background) from jackruguile.com.  Removed this asset with no functional changes except Jack no longer receives requests leaking IPs from every report view.

#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [] The code is both Python 2 and Python 3 compatible.
- [] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [] This Pull Request relates to only one issue or only one feature
- [ ] I have referenced the corresponding issue number in my commit message
- [ ] I have added the relevant documentation.
- [x] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
* Remove external asset from report css - no visual / functional changes.

#### Your development environment
- OS: `Linux`
- OS Version: `Debian 10`
- Python Version: `3.7.3`
