### PR TITLE
KeyError in wappalyzer_scan module when IIS is discovered error solved #338

### DIFF
--- a/lib/scan/wappalyzer/apps.json
+++ b/lib/scan/wappalyzer/apps.json
@@ -5877,7 +5877,7 @@
       },
       "html": "<input[^>]+name=\"__VIEWSTATE",
       "icon": "Microsoft ASP.NET.png",
-      "implies": "IIS\\;confidence:50",
+      "implies": "IIS",
       "url": "\\.aspx(?:$|\\?)",
       "website": "http://www.asp.net"
     },


### PR DESCRIPTION
#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [x] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [x] The code is both Python 2 and Python 3 compatible.
- [x] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [x] This Pull Request relates to only one issue or only one feature
- [x] I have added the relevant documentation.
- [x] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request

Here when line 174 in engine.py of the module cats = apps[app_name]['cats'] executes return keyerror because key "IIS\\;confidence:50" doesn't exist in app json. 

changes on line 5880 in app.json as "implies": "IIS\\;confidence:50" to "implies": "IIS" . After implementing this i validated the output i get through wappalyzer_scan module with wappalyzer chrome extension.


#### Your development environment
- OS: `Backbox`
- OS Version: `7.1`
- Python Version: `3.8`
