### PR TITLE
Change old hardcoded reference to OWASP repo #363

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 Developers
 ==========
-Hello, if anyone interested to contribute OWASP Nettacker Project, we gladly support and appreciate that! Please take a look at [Developers Document](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers) on wiki page and let me know if you have more questions.
+Hello, if anyone interested to contribute OWASP Nettacker Project, we gladly support and appreciate that! Please take a look at [Developers Document](https://github.com/OWASP/Nettacker/wiki/Developers) on wiki page and let me know if you have more questions.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 #### Checklist
-- [ ] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
+- [ ] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
 - [ ] The code has been thoroughly tested in my local development environment with flake8 and pylint.
 - [ ] The code is both Python 2 and Python 3 compatible.
 - [ ] The code follows the PEP8 styling guidelines with 4 spaces indentation.

--- a/core/update.py
+++ b/core/update.py
@@ -41,7 +41,7 @@ def _update(__version__, __code_name__, language, socks_proxy):
             socket.getaddrinfo = getaddrinfo
         data = requests.get(
             url, headers={"User-Agent": "OWASP Nettacker"}).content
-        if version() is 3:
+        if version() == 3:
             data = data.decode("utf-8")
         if __version__ + ' ' + __code_name__ == data.rsplit('\n')[0]:
             info(messages(language, "last_version"))
@@ -100,7 +100,7 @@ def _check(__version__, __code_name__, language, socks_proxy):
             socket.getaddrinfo = getaddrinfo
         data = requests.get(
             url, headers={"User-Agent": "OWASP Nettacker"}).content
-        if version() is 3:
+        if version() == 3:
             data = data.decode("utf-8")
         if __version__ + ' ' + __code_name__ == data.rsplit('\n')[0]:
             info(messages(language, "last_version"))

--- a/core/update.py
+++ b/core/update.py
@@ -16,6 +16,7 @@ from datetime import datetime
 
 url = 'https://raw.githubusercontent.com/zdresearch/OWASP-Nettacker/master/version.txt'
 
+
 def _update(__version__, __code_name__, language, socks_proxy):
     """
     update the framework
@@ -51,12 +52,13 @@ def _update(__version__, __code_name__, language, socks_proxy):
         warn(messages(language, "cannot_update"))
     return True
 
+
 def _update_check(language):
     """
     This Function checks if an Update has happened in the previous day and if not, it checks for update
 
     Args:
-        Language
+        language
     Return:
         True or False depending on if update should happen or not
     """
@@ -65,12 +67,13 @@ def _update_check(language):
     except Exception:
         save_update_log(language)
         logs = (get_update_log(language))
-    logs2 = (logs[len(logs)-1].last_update_time)
+    logs2 = logs[len(logs)-1].last_update_time
     if datetime.now() > datetime.strptime(logs2, "%Y-%m-%d %H:%M:%S.%f") + timedelta(days=1):
         save_update_log(language)
         return True
     else:
         return False
+
 
 def _check(__version__, __code_name__, language, socks_proxy):
     """
@@ -85,7 +88,7 @@ def _check(__version__, __code_name__, language, socks_proxy):
     Returns:
         True if success otherwise None
     """
-#    print(save_update_log(language))
+
     try:
         if socks_proxy is not None:
             socks_version = socks.SOCKS5 if socks_proxy.startswith(

--- a/lib/graph/d3_tree_v1/engine.py
+++ b/lib/graph/d3_tree_v1/engine.py
@@ -11899,6 +11899,6 @@ treeJSON = d3.json("https://github.com/OWASP/Nettacker", function(error, treeDat
         .replace('__title_to_replace__', messages(language, "pentest_graphs")) \
         .replace('__description_to_replace__', messages(language, "graph_message")) \
         .replace('__html_title_to_replace__', messages(language, "nettacker_report"))
-    if version() is 2:
+    if version() == 2:
         return data.decode('utf8')
     return data

--- a/lib/graph/d3_tree_v1/engine.py
+++ b/lib/graph/d3_tree_v1/engine.py
@@ -60,7 +60,7 @@ def start(graph_flag, language, data, _HOST, _USERNAME, _PASSWORD, _PORT, _TYPE,
 <title>__html_title_to_replace__</title>
 <meta charset="utf-8">
 <div class="header">
-    <h3><a href="https://github.com/zdresearch/nettacker">OWASP Nettacker</a></h3>
+    <h3><a href="https://github.com/OWASP/Nettacker">OWASP Nettacker</a></h3>
     <h3>__title_to_replace__</h3>
 </div>
 <style type="text/css">
@@ -11404,7 +11404,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
 
 
 // Get JSON data
-treeJSON = d3.json("https://github.com/zdresearch/OWASP-Nettacker", function(error, treeData) {
+treeJSON = d3.json("https://github.com/OWASP/Nettacker", function(error, treeData) {
 
     // Calculate total nodes, max label length
     treeData = __data_will_locate_here__;

--- a/lib/graph/jit_circle_v1/engine.py
+++ b/lib/graph/jit_circle_v1/engine.py
@@ -203,7 +203,7 @@ a {
 }
 
 </style>
-<a target="_blank" href="https://github.com/zdresearch/OWASP-Nettacker"><h2>OWASP Nettacker</h2></a>
+<a target="_blank" href="https://github.com/OWASP/Nettacker"><h2>OWASP Nettacker</h2></a>
 <!--[if IE]><script language="javascript" type="text/javascript" src="../../Extras/excanvas.js"></script><![endif]-->
 
 <!-- JIT Library File -->

--- a/lib/graph/jit_circle_v1/engine.py
+++ b/lib/graph/jit_circle_v1/engine.py
@@ -14805,6 +14805,6 @@ __title_to_replace__
         .replace('__title_to_replace__', messages(language, "pentest_graphs")) \
         .replace('__description_to_replace__', messages(language, "graph_message")) \
         .replace('__html_title_to_replace__', messages(language, "nettacker_report"))
-    if version() is 2:
+    if version() == 2:
         return data.decode('utf8')
     return data

--- a/lib/language/messages_ar.py
+++ b/lib/language/messages_ar.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "بدأ محرك Nettacker ...",
             "options": "python nettacker.py [خيارات]",
             "help_menu": "عرض قائمة مساعدة Nettacker",
-            "license": "يرجى قراءة الترخيص والاتفاقيات https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "يرجى قراءة الترخيص والاتفاقيات https://github.com/OWASP/Nettacker",
             "engine": "محرك",
             "engine_input": "خيارات إدخال المحرك",
             "select_language": "اختر لغة {0}",
@@ -103,7 +103,7 @@ def all_messages():
             "target_submitted": "الهدف {0} مقدم!",
             "current_version": "أنت تشغل إصدار OWASP Nettacker {0} {1} {2} {6} مع اسم الكود {3} {4} {5}",
             "feature_unavailable": "هذه الميزة غير متوفرة بعد! يرجى تشغيل "
-                                   "\"بوابة استنساخ https://github.com/zdresearch/OWASP-Nettacker.git أ"
+                                   "\"بوابة استنساخ https://github.com/OWASP/Nettacker.git أ"
                                    "و نقطة تثبيت -U OWASP-Nettacker للحصول على الإصدار الأخير.",
             "available_graph": "بناء رسم بياني لجميع الأنشطة"
                                " والمعلومات ، يجب عليك استخدام مخرجات HTML. الرسوم البيانية المتاحة: {0}",

--- a/lib/language/messages_de.py
+++ b/lib/language/messages_de.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Nettacker Motor gestartet ...",
             "options": "python nettacker.py [Optionen]",
             "help_menu": "Zeige Nettacker Hilfe-Menü",
-            "license": "Bitte lesen Sie die Lizenz und die Vereinbarungen https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "Bitte lesen Sie die Lizenz und die Vereinbarungen https://github.com/OWASP/Nettacker",
             "engine": "Motor",
             "engine_input": "Motoreingangsoptionen",
             "select_language": "wähle eine Sprache {0}",
@@ -106,7 +106,7 @@ def all_messages():
             "target_submitted": "Ziel {0} gesendet!",
             "current_version": "Sie führen die OWASP Nettacker-Version {0} {1} {2} {6} mit dem Codenamen {3} {4} {5}",
             "feature_unavailable": "Diese Funktion ist noch nicht verfügbar! bitte starte \"git "
-                                   "clone https://github.com/zdresearch/OWASP-Nettacker.git oder pip install -U "
+                                   "clone https://github.com/OWASP/Nettacker.git oder pip install -U "
                                    "OWASP-Nettacker um die letzte Version zu erhalten.",
             "available_graph": "Erstellen Sie ein Diagramm aller Aktivitäten und Informationen, Sie müssen "
                                "HTML-Ausgabe verwenden. verfügbare Diagramme: {0}",

--- a/lib/language/messages_el.py
+++ b/lib/language/messages_el.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Ο μηχανισμός Nettacker ξεκίνησε ...",
             "options": "python nettacker.py [επιλογές]",
             "help_menu": "Εμφάνιση του μενού βοήθειας Nettacker",
-            "license": "Διαβάστε τις άδειες και τις συμφωνίες https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "Διαβάστε τις άδειες και τις συμφωνίες https://github.com/OWASP/Nettacker",
             "engine": "Κινητήρας",
             "engine_input": "Επιλογές εισαγωγής κινητήρα",
             "select_language": "επιλέξτε μια γλώσσα {0}",
@@ -111,7 +111,7 @@ def all_messages():
             "target_submitted": "ο στόχος {0} υποβλήθηκε!",
             "current_version": "εκτελείτε την έκδοση OWASP Nettacker {0} {1} {2} {6} με το όνομα κώδικα {3} {4} {5}",
             "feature_unavailable": "αυτή η λειτουργία δεν είναι ακόμα διαθέσιμη! εκτελέστε τον "
-                                   "\"git clone https://github.com/zdresearch/OWASP-Nettacker.git ή "
+                                   "\"git clone https://github.com/OWASP/Nettacker.git ή "
                                    "εγκαταστήστε pip -U OWASP-Nettacker για να λάβετε την τελευταία έκδοση.",
             "available_graph": "να δημιουργήσετε ένα γράφημα όλων των δραστηριοτήτων και πληροφοριών, "
                                "πρέπει να χρησιμοποιήσετε την έξοδο HTML. διαθέσιμα γραφήματα: {0}",

--- a/lib/language/messages_en.py
+++ b/lib/language/messages_en.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Nettacker engine started ...\n\n",
             "options": "python nettacker.py [options]",
             "help_menu": "Show Nettacker Help Menu",
-            "license": "Please read license and agreements https://github.com/zdresearch/OWASP-Nettacker\n",
+            "license": "Please read license and agreements https://github.com/OWASP/Nettacker\n",
             "engine": "Engine",
             "engine_input": "Engine input options",
             "select_language": "select a language {0}",
@@ -104,7 +104,7 @@ def all_messages():
             "target_submitted": "target {0} submitted!",
             "current_version": "you are running OWASP Nettacker version {0}{1}{2}{6} with code name {3}{4}{5}",
             "feature_unavailable": "this feature is not available yet! please run \"git clone "
-                                   "https://github.com/zdresearch/OWASP-Nettacker.git or pip install"
+                                   "https://github.com/OWASP/Nettacker.git or pip install"
                                    " -U OWASP-Nettacker to get the latest version.",
             "available_graph": "build a graph of all activities and information, you must"
                                " use HTML output. available graphs: {0}",

--- a/lib/language/messages_es.py
+++ b/lib/language/messages_es.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "El motor Nettacker comenzó ...",
             "options": "python nettacker.py [opciones]",
             "help_menu": "Mostrar el menú de ayuda de Nettacker",
-            "license": "Lea la licencia y los acuerdos https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "Lea la licencia y los acuerdos https://github.com/OWASP/Nettacker",
             "engine": "Motor",
             "engine_input": "Opciones de entrada del motor",
             "select_language": "seleccione un idioma {0}",
@@ -108,7 +108,7 @@ def all_messages():
             "current_version": "está ejecutando la versión de OWASP Nettacker {0} {1} {2} {6} con el nombre de "
                                "código {3} {4} {5}",
             "feature_unavailable": "esta característica aún no está disponible por favor, ejecute \"git clone "
-                                   "https://github.com/zdresearch/OWASP-Nettacker.git or pip install -U "
+                                   "https://github.com/OWASP/Nettacker.git or pip install -U "
                                    "OWASP-Nettacker para obtener la última versión.",
             "available_graph": "crea un gráfico de todas las actividades y la información, debes usar la "
                                "salida HTML. gráficos disponibles: {0}",

--- a/lib/language/messages_fa.py
+++ b/lib/language/messages_fa.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "انجین Nettacker آغاز به کار کرد ...\n\n",
             "options": "python nettacker.py [گزینه ها]",
             "help_menu": "نشان دادن منوی کمک Nettacker",
-            "license": "لطفا مجوز و موافقت نامه را مطالعه فرمایید https://github.com/zdresearch/OWASP-Nettacker\n",
+            "license": "لطفا مجوز و موافقت نامه را مطالعه فرمایید https://github.com/OWASP/Nettacker\n",
             "engine": "انجین",
             "engine_input": "گزینه های ورودی انجین",
             "select_language": "یک زبان انتخاب کنید {0}",
@@ -106,7 +106,7 @@ def all_messages():
             "target_submitted": "هدف {0} ارسال شد!",
             "current_version": "شما در حال اجرای OWASP Nettacker ورژن {0}{1}{2}{6} با اسم کد {3}{4}{5} می باشید",
             "feature_unavailable": "این ویژگی هنوز فعال نشده است! لطفا "
-                                   "\"git clone https://github.com/zdresearch/OWASP-Nettacker.git\""
+                                   "\"git clone https://github.com/OWASP/Nettacker.git\""
                                    " یا \"pip install -U OWASP-Nettacker\" را جهت گرفتن اخرین ورژن اجرا کنید.",
             "available_graph": "ساخت گراف از همه فعالیت ها و اطلاعات، شما باید"
                                " از خروجی HTML استفاده کنید. گراف های در دسترس: {0}",

--- a/lib/language/messages_fr.py
+++ b/lib/language/messages_fr.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Moteur Nettacker a commencé ...",
             "options": "python nettacker.py [options]",
             "help_menu": "Afficher le menu d'aide de Nettacker",
-            "license": "S'il vous plaît lire la licence et les accords https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "S'il vous plaît lire la licence et les accords https://github.com/OWASP/Nettacker",
             "engine": "Moteur",
             "engine_input": "Options de saisie du moteur",
             "select_language": "sélectionner une langue {0}",
@@ -111,7 +111,7 @@ def all_messages():
             "current_version": "vous utilisez la version OWASP Nettacker {0} {1} {2} {6} avec le "
                                "nom de code {3} {4} {5}",
             "feature_unavailable": "cette fonctionnalité n'est pas encore disponible! S'il vous plaît exécuter"
-                                   " \"git clone https://github.com/zdresearch/OWASP-Nettacker.git ou pip "
+                                   " \"git clone https://github.com/OWASP/Nettacker.git ou pip "
                                    "installer -U OWASP-Nettacker pour obtenir la dernière version.",
             "available_graph": "construire un graphique de toutes les activités et informations, vous devez"
                                " utiliser la sortie HTML. graphiques disponibles: {0}",

--- a/lib/language/messages_hi.py
+++ b/lib/language/messages_hi.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "नेटटेकर इंजन शुरू हुआ ...",
             "options": "पायथन nettacker.py [विकल्प]",
             "help_menu": "नेटटेकर सहायता मेनू दिखाएं",
-            "license": "कृपया लाइसेंस और समझौते https://github.com/zdresearch/OWASP-Nettacker पढ़ें",
+            "license": "कृपया लाइसेंस और समझौते https://github.com/OWASP/Nettacker पढ़ें",
             "engine": "इंजन",
             "engine_input": "इंजन इनपुट विकल्प",
             "select_language": "एक भाषा का चयन करें {0}",
@@ -100,7 +100,7 @@ def all_messages():
             "target_submitted": "लक्ष्य {0} जमा!",
             "current_version": "आप OWASP Nettacker संस्करण {0} {1} {2} {6} कोड नाम {3} {4} {5} के साथ चल रहे हैं",
             "feature_unavailable": "यह सुविधा अभी तक उपलब्ध नहीं है! अंतिम संस्करण प्राप्त करने के लिए कृपया \"गिट क्लोन "
-                                   "https://github.com/zdresearch/OWASP-Nettacker.git या पाइप इंस्टॉल -यू"
+                                   "https://github.com/OWASP/Nettacker.git या पाइप इंस्टॉल -यू"
                                    " OWASP-Nettacker चलाएं।",
             "available_graph": "सभी गतिविधियों और जानकारी का एक ग्राफ बनाएं, आपको HTML आउटपुट का उपयोग करना होगा।"
                                " उपलब्ध ग्राफ: {0}",

--- a/lib/language/messages_hy.py
+++ b/lib/language/messages_hy.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Nettacker շարժիչը սկսվեց ...",
             "options": "python nettacker.py [ընտրանքներ]",
             "help_menu": "Ցույց տալ Nettacker Օգնություն Մենյու",
-            "license": "Խնդրում ենք կարդալ լիցենզիա եւ համաձայնագրեր https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "Խնդրում ենք կարդալ լիցենզիա եւ համաձայնագրեր https://github.com/OWASP/Nettacker",
             "engine": "Շարժիչ",
             "engine_input": "Շարժիչի ներածման ընտրանքները",
             "select_language": "{0} լեզու ընտրել",
@@ -103,7 +103,7 @@ def all_messages():
             "target_submitted": "թիրախ {0} ներկայացվեց:",
             "current_version": "Դուք աշխատում եք {0} {1} {2} {6} - ի OWASP Nettacker տարբերակով {3} {4} {5}",
             "feature_unavailable": "այս հատկությունը հասանելի չէ: խնդրում ենք վազել \"git clone "
-                                   "https://github.com/zdresearch/OWASP-Nettacker.git կամ pip install "
+                                   "https://github.com/OWASP/Nettacker.git կամ pip install "
                                    "-U OWASP-Nettacker ստանալ վերջին տարբերակը:",
             "available_graph": "կառուցեք բոլոր գործողությունների եւ տեղեկատվության գրաֆիկ, դուք պետք է "
                                "օգտագործեք HTML արտադրանքը: մատչելի գրաֆիկները `{0}",

--- a/lib/language/messages_id.py
+++ b/lib/language/messages_id.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Mesin Nettacker mulai ...",
             "options": "python nettacker.py [opsi]",
             "help_menu": "Tampilkan Menu Bantuan Nettacker",
-            "license": "Harap baca lisensi dan perjanjian https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "Harap baca lisensi dan perjanjian https://github.com/OWASP/Nettacker",
             "engine": "Mesin",
             "engine_input": "Opsi masukan mesin",
             "select_language": "pilih bahasa {0}",
@@ -104,7 +104,7 @@ def all_messages():
             "target_submitted": "target {0} dikirimkan!",
             "current_version": "Anda menjalankan OWASP Nettacker versi {0} {1} {2} {6} dengan nama kode {3} {4} {5}",
             "feature_unavailable": "fitur ini belum tersedia! silakan jalankan \"git clone "
-                                   "https://github.com/zdresearch/OWASP-Nettacker.git atau install pip -U"
+                                   "https://github.com/OWASP/Nettacker.git atau install pip -U"
                                    " OWASP-Nettacker untuk mendapatkan versi terakhir.",
             "available_graph": "membangun grafik dari semua aktivitas dan informasi, Anda harus menggunakan "
                                "output HTML. grafik yang tersedia: {0}",

--- a/lib/language/messages_it.py
+++ b/lib/language/messages_it.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Il motore Nettacker ha iniziato ...",
             "options": "python nettacker.py [opzioni]",
             "help_menu": "Mostra il menu Aiuto di Nettacker",
-            "license": "Si prega di leggere la licenza e gli accordi https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "Si prega di leggere la licenza e gli accordi https://github.com/OWASP/Nettacker",
             "engine": "Motore",
             "engine_input": "Opzioni di input del motore",
             "select_language": "seleziona una lingua {0}",
@@ -106,7 +106,7 @@ def all_messages():
             "current_version": "stai eseguendo la versione di OWASP Nettacker {0} {1} {2} {6} con il nome in codice"
                                " {3} {4} {5}",
             "feature_unavailable": "questa funzione non è ancora disponibile! per favore lancia \"git clone "
-                                   "https://github.com/zdresearch/OWASP-Nettacker.git o pip install -U OWASP-Nettacker "
+                                   "https://github.com/OWASP/Nettacker.git o pip install -U OWASP-Nettacker "
                                    "per ottenere l'ultima versione.",
             "available_graph": "costruire un grafico di tutte le attività e le informazioni, è necessario utilizzare"
                                " l'output HTML. grafici disponibili: {0}",

--- a/lib/language/messages_iw.py
+++ b/lib/language/messages_iw.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "מנוע Nettacker התחיל ...",
             "options": "python nettacker.py [אפשרויות]",
             "help_menu": "הצג תפריט עזרה Nettacker",
-            "license": "קרא את הרישיון וההסכמים https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "קרא את הרישיון וההסכמים https://github.com/OWASP/Nettacker",
             "engine": "מנוע",
             "engine_input": "אפשרויות קלט מנוע",
             "select_language": "בחר שפה {0}",
@@ -99,7 +99,7 @@ def all_messages():
             "target_submitted": "יעד {0} נשלח!",
             "current_version": "אתה מפעיל את גרסת OWASP Nettacker {0} {1} {2} {6} עם שם קוד {3} {4} {5}",
             "feature_unavailable": "תכונה זו אינה זמינה עדיין! בבקשה להפעיל \"git"
-                                   " שיבוט https://github.com/zdresearch/OWASP-Nettacker.git או להתקין "
+                                   " שיבוט https://github.com/OWASP/Nettacker.git או להתקין "
                                    "פיפס -U OWASP-Nettacker כדי לקבל את הגירסה האחרונה.",
             "available_graph": "לבנות גרף של כל הפעילויות והמידע, עליך להשתמש בפלט HTML. גרפים זמינים: {0}",
             "graph_output": "כדי להשתמש בתכונת הגרף שם קובץ הפלט שלך חייב להסתיים עם \".html\" או \".htm\"!",

--- a/lib/language/messages_ja.py
+++ b/lib/language/messages_ja.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Nettackerエンジンが始動しました...",
             "options": "python nettacker.py [options]",
             "help_menu": "Nettackerヘルプメニューを表示する",
-            "license": "ライセンスと契約書をお読みくださいhttps://github.com/zdresearch/OWASP-Nettacker",
+            "license": "ライセンスと契約書をお読みくださいhttps://github.com/OWASP/Nettacker",
             "engine": "エンジン",
             "engine_input": "エンジン入力オプション",
             "select_language": "言語を選択{0}",
@@ -98,8 +98,8 @@ def all_messages():
             "port_found": "ホスト：{0}ポート：{1}（{2}）が見つかりました！",
             "target_submitted": "ターゲット{0}が送信されました。",
             "current_version": "OWASP Nettackerのバージョン{0} {1} {2} {6}をコード名{3} {4} {5}で実行しています。",
-            "feature_unavailable": "この機能はまだ利用できません。 「git clone https://github.com/zdresearch/"
-                                   "OWASP-Nettacker.git」または「pip install -U OWASP-Nettacker」を実行して、"
+            "feature_unavailable": "この機能はまだ利用できません。 「git clone https://github.com/OWASP/"
+                                   "Nettacker.git」または「pip install -U OWASP-Nettacker」を実行して、"
                                    "最新バージョンを入手してください。",
             "available_graph": "すべての活動と情報のグラフを作成するには、HTML出力を使用する必要があります。利用可能なグラフ：{0}",
             "graph_output": "グラフフィーチャを使用するには、出力ファイル名が \".html\"または \".htm\"で終わる必要があります。",

--- a/lib/language/messages_ko.py
+++ b/lib/language/messages_ko.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Nettacker 엔진이 시작되었습니다 ...",
             "options": "python nettacker.py [options]",
             "help_menu": "Nettacker 도움말 메뉴 표시",
-            "license": "라이센스 및 계약서를 읽으십시오. https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "라이센스 및 계약서를 읽으십시오. https://github.com/OWASP/Nettacker",
             "engine": "엔진",
             "engine_input": "엔진 입력 옵션",
             "select_language": "언어 선택 {0}",
@@ -100,7 +100,7 @@ def all_messages():
             "target_submitted": "타겟 {0}이 제출되었습니다.",
             "current_version": "당신은 코드 이름 {3} {4} {5}로 OWASP Nettacker 버전 {0} {1} {2} {6}",
             "feature_unavailable": "아직이 기능을 사용할 수 없습니다. 마지막 버전을 얻으려면 \"git clone https:"
-                                   "//github.com/zdresearch/OWASP-Nettacker.git 또는 pip install -U OWASP-Nettacker"
+                                   "//github.com/OWASP/Nettacker.git 또는 pip install -U OWASP-Nettacker"
                                    "를 실행하십시오.",
             "available_graph": "모든 활동 및 정보의 그래프를 작성하려면 HTML 출력을 사용해야합니다. 사용 가능한 그래프 : {0}",
             "graph_output": "그래프 기능을 사용하려면 출력 파일 이름이 \".html\"또는 \".htm\"로 끝나야합니다!",

--- a/lib/language/messages_nl.py
+++ b/lib/language/messages_nl.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Nettacker-motor is gestart ...",
             "options": "python nettacker.py [opties]",
             "help_menu": "Toon Nettacker Help Menu",
-            "license": "Lees de licentie en overeenkomsten https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "Lees de licentie en overeenkomsten https://github.com/OWASP/Nettacker",
             "engine": "Motor",
             "engine_input": "Motor invoeropties",
             "select_language": "selecteer een taal {0}",
@@ -107,7 +107,7 @@ def all_messages():
             "target_submitted": "target {0} ingediend!",
             "current_version": "u gebruikt OWASP Nettacker-versie {0} {1} {2} {6} met codenaam {3} {4} {5}",
             "feature_unavailable": "deze functie is nog niet beschikbaar! voer alstublieft \"git clone "
-                                   "https://github.com/zdresearch/OWASP-Nettacker.git or pip install -U "
+                                   "https://github.com/OWASP/Nettacker.git or pip install -U "
                                    "OWASP-Nettacker uit om de laatste versie te krijgen.",
             "available_graph": "maak een grafiek van alle activiteiten en informatie, gebruik HTML-uitvoer. "
                                "beschikbare grafieken: {0}",

--- a/lib/language/messages_ps.py
+++ b/lib/language/messages_ps.py
@@ -13,7 +13,7 @@ def all_messages():
             "scan_started": "د نیټیکر انجنیر پیل شو",
             "options": "پیډون nettacker.py [اختیارونه]",
             "help_menu": "د Nettacker د مرستې مینو ښودل",
-            "license": "مهرباني وکړئ لايسنس او ​​تړونونه وګورئ https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "مهرباني وکړئ لايسنس او ​​تړونونه وګورئ https://github.com/OWASP/Nettacker",
             "engine": "انجن",
             "engine_input": "د انجن د وسیلو اختیارونه",
             "select_language": "یوه ژبه وټاکئ {0}",
@@ -99,7 +99,7 @@ def all_messages():
             "target_submitted": "هدف {0} ورکړل شوی!",
             "current_version": "تاسو د OWASP نټیکریر نسخه چلول {0} {1} {2} {6} د کوډ نوم {3} {4} {5}",
             "feature_unavailable": "دا فیچر لا تر اوسه شتون"
-                                   " نلري! مهرباني وکړئ \"ګټ کلون https://github.com/zdresearch/OWASP-Nettacker.git\""
+                                   " نلري! مهرباني وکړئ \"ګټ کلون https://github.com/OWASP/Nettacker.git\""
                                    " یا \"پایپ لاین\" نصب کړئ - د OWASP-Nettacker وروستی نسخه ترلاسه کولو لپاره.",
             "available_graph": "د ټولو فعالیتونو او معلوماتو گراف"
                                " جوړ کړئ، تاسو باید د HTML محصول کاروئ. موجود ګرافونه: {0}",

--- a/lib/language/messages_ru.py
+++ b/lib/language/messages_ru.py
@@ -15,7 +15,7 @@ def all_messages():
             "options": "python nettacker.py [опции]",
             "help_menu": "Показать меню справки Nettacker",
             "license": "Пожалуйста, ознакомьтесь с лицензией и соглашениями"
-                       " https://github.com/zdresearch/OWASP-Nettacker",
+                       " https://github.com/OWASP/Nettacker",
             "engine": "двигатель",
             "engine_input": "Параметры ввода двигателя",
             "select_language": "выберите язык {0}",
@@ -104,8 +104,8 @@ def all_messages():
             "port_found": "host: {0} порт: {1} ({2}) найден!",
             "target_submitted": "target {0}!",
             "current_version": "вы используете версию OWASP Nettacker {0} {1} {2} {6} с кодовым названием {3} {4} {5}",
-            "feature_unavailable": "эта функция пока недоступна! запустите «git clone https://github.com/zdresearch"
-                                   "/OWASP-Nettacker.git или pip install -U OWASP-Nettacker, чтобы получить "
+            "feature_unavailable": "эта функция пока недоступна! запустите «git clone https://github.com/OWASP"
+                                   "/Nettacker.git или pip install -U OWASP-Nettacker, чтобы получить "
                                    "последнюю версию.",
             "available_graph": "постройте график всех действий и информации, вы должны использовать вывод HTML. "
                                "доступные графики: {0}",

--- a/lib/language/messages_tr.py
+++ b/lib/language/messages_tr.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Nettacker motoru başladı ...",
             "options": "python nettacker.py [seçenekler]",
             "help_menu": "Nettacker Yardım Menüsünü Göster",
-            "license": "Lütfen lisans ve sözleşmeleri okuyun https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "Lütfen lisans ve sözleşmeleri okuyun https://github.com/OWASP/Nettacker",
             "engine": "Motor",
             "engine_input": "Motor girişi seçenekleri",
             "select_language": "bir dil seçin {0}",
@@ -102,7 +102,7 @@ def all_messages():
             "target_submitted": "{0} hedefi gönderildi!",
             "current_version": "{0} {1} {2} {6} OWASP Nettacker sürümünü {3} {4} {5} kod adıyla çalıştırıyorsunuz",
             "feature_unavailable": "Bu özellik henüz mevcut değil! son sürümü almak için lütfen git klon "
-                                   "https://github.com/zdresearch/OWASP-Nettacker.git veya pip install -U"
+                                   "https://github.com/OWASP/Nettacker.git veya pip install -U"
                                    " OWASP-Nettacker çalıştırın.",
             "available_graph": "Tüm aktiviteler ve bilgiler için bir grafik oluşturmak, HTML çıkışı kullanmalısınız."
                                " mevcut grafikler: {0}",

--- a/lib/language/messages_ur.py
+++ b/lib/language/messages_ur.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Nettacker انجن شروع کر دیا ...",
             "options": "پادری nettacker.py [اختیارات]",
             "help_menu": "Nettacker مدد مینو دکھائیں",
-            "license": "برائے مہربانی لائسنس اور معاہدوں کو https://github.com/zdresearch/OWASP-Nettacker پڑھیں",
+            "license": "برائے مہربانی لائسنس اور معاہدوں کو https://github.com/OWASP/Nettacker پڑھیں",
             "engine": "انجن",
             "engine_input": "انجن ان پٹ کے اختیارات",
             "select_language": "ایک زبان منتخب کریں {0}",
@@ -104,7 +104,7 @@ def all_messages():
             "target_submitted": "ھدف کردہ {0}",
             "current_version": "آپ OWASP Nettacker ورژن {0} {1} {2} {6} کوڈ چل رہے ہیں {کوڈ} {3} {4} {5}",
             "feature_unavailable": "یہ خصوصیت ابھی تک دستیاب نہیں ہے! "
-                                   "براہ کرم \"گٹ کلون https://github.com/zdresearch/OWASP-Nettacker.git یا"
+                                   "براہ کرم \"گٹ کلون https://github.com/OWASP/Nettacker.git یا"
                                    " انسٹال پائپ انسٹال کریں. - OWASP-Nettacker آخری ورژن حاصل کرنے کے لئے.",
             "available_graph": "تمام سرگرمیوں اور معلومات"
                                " کا گراف بناؤ، آپ کو HTML پیداوار استعمال کرنا ضروری ہے. دستیاب گرافس: {0}",

--- a/lib/language/messages_vi.py
+++ b/lib/language/messages_vi.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Động cơ Nettacker đã bắt đầu ...",
             "options": "python nettacker.py [tùy chọn]",
             "help_menu": "Hiển thị menu trợ giúp Nettacker",
-            "license": "Vui lòng đọc giấy phép và thỏa thuận https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "Vui lòng đọc giấy phép và thỏa thuận https://github.com/OWASP/Nettacker",
             "engine": "Động cơ",
             "engine_input": "Tùy chọn đầu vào của động cơ",
             "select_language": "chọn ngôn ngữ {0}",
@@ -100,8 +100,8 @@ def all_messages():
             "port_found": "host: {0} port: {1} ({2}) được tìm thấy!",
             "target_submitted": "mục tiêu {0} đã được gửi!",
             "current_version": "bạn đang chạy phiên bản OWASP Nettacker {0} {1} {2} {6} với tên mã {3} {4} {5}",
-            "feature_unavailable": "tính năng này chưa khả dụng! hãy chạy \"git clone https://github.com/zdresearch/"
-                                   "OWASP-Nettacker.git hoặc pip install -U OWASP-Nettacker "
+            "feature_unavailable": "tính năng này chưa khả dụng! hãy chạy \"git clone https://github.com/OWASP/"
+                                   "Nettacker.git hoặc pip install -U OWASP-Nettacker "
                                    "để lấy phiên bản cuối cùng.",
             "available_graph": "xây dựng một biểu đồ của tất cả các hoạt động và thông tin, bạn phải sử"
                                " dụng đầu ra HTML. đồ thị có sẵn: {0}",

--- a/lib/language/messages_zh-cn.py
+++ b/lib/language/messages_zh-cn.py
@@ -14,7 +14,7 @@ def all_messages():
             "scan_started": "Nettacker 启动...",
             "options": "python nettacker.py [选项]",
             "help_menu": "显示 Nettacker 菜单",
-            "license": "请阅读许可证和协议 https://github.com/zdresearch/OWASP-Nettacker",
+            "license": "请阅读许可证和协议 https://github.com/OWASP/Nettacker",
             "engine": "Nettacker",
             "engine_input": "选项",
             "select_language": "选择一种语言{0}",
@@ -96,7 +96,7 @@ def all_messages():
             "port_found": "主机：{0}端口：{1}（{2}）找到了！",
             "target_submitted": "目标{0}已提交！",
             "current_version": "您正在运行代码为{3} {4} {5}的 OWASP Nettacker 版本{0} {1} {2} {6}",
-            "feature_unavailable": "此功能尚未提供！请运行“git clone https://github.com/zdresearch/OWASP-Nettacker.git"
+            "feature_unavailable": "此功能尚未提供！请运行“git clone https://github.com/OWASP/Nettacker.git"
                                    "或 pip install -U OWASP-Nettacker 来获取最新版本。",
             "available_graph": "建立所有活动和信息的图表，您必须使用 HTML 输出。可用图表：{0}",
             "graph_output": "要使用图表功能，您的输出文件名必须以“.html”或“.htm”结尾！",

--- a/lib/vuln/wordpress_dos_cve_2018_6389/engine.py
+++ b/lib/vuln/wordpress_dos_cve_2018_6389/engine.py
@@ -4,7 +4,7 @@
 # references
 # https://www.youtube.com/watch?v=nNDsGTalXS0
 # https://baraktawily.blogspot.nl/2018/02/how-to-dos-29-of-world-wide-websites.html
-# https://github.com/zdresearch/OWASP-Nettacker/blob/master/lib/vuln/wordpress_dos_cve_2018_6389/engine.py
+# https://github.com/OWASP/Nettacker/blob/master/lib/vuln/wordpress_dos_cve_2018_6389/engine.py
 
 import socket
 import socks

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,10 @@ OWASP Nettacker
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/04ca57d1b996435d8a42c767add84859)](https://www.codacy.com/app/zdresearch/OWASP-Nettacker?utm_source=github.com&utm_medium=referral&utm_content=zdresearch/OWASP-Nettacker&utm_campaign=Badge_Coverage)
 [![Python 2.x](https://img.shields.io/badge/python-2.x-blue.svg)](https://travis-ci.org/zdresearch/OWASP-Nettacker)
 [![Python 3.x](https://img.shields.io/badge/python-3.x-blue.svg)](https://travis-ci.org/zdresearch/OWASP-Nettacker)
-[![Apache License](https://img.shields.io/badge/License-Apache%20v2-green.svg)](https://github.com/zdresearch/OWASP-Nettacker/blob/master/LICENSE)
+[![Apache License](https://img.shields.io/badge/License-Apache%20v2-green.svg)](https://github.com/OWASP/Nettacker/blob/master/LICENSE)
 [![Twitter](https://img.shields.io/badge/Twitter-@iotscan-blue.svg)](https://twitter.com/iotscan)
 ![GitHub contributors](https://img.shields.io/github/contributors/zdresearch/OWASP-Nettacker)
-[![repo size ](https://img.shields.io/github/repo-size/zdresearch/OWASP-Nettacker)](https://github.com/zdresearch/OWASP-Nettacker)
+[![repo size ](https://img.shields.io/github/repo-size/zdresearch/OWASP-Nettacker)](https://github.com/OWASP/Nettacker)
 
 
 <img src="https://raw.githubusercontent.com/zdresearch/OWASP-Nettacker/master/web/static/img/owasp-nettacker.png" width="200"><img src="https://raw.githubusercontent.com/zdresearch/OWASP-Nettacker/master/web/static/img/owasp.png" width="500">

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     package_data={"": package_files()},
     include_package_data=True,
     install_requires=requirements(),
-    url="https://github.com/zdresearch/OWASP-Nettacker",
+    url="https://github.com/OWASP/Nettacker",
     license="Apache-2.0",
     author="Ali Razmjoo",
     author_email="ali.razmjoo@owasp.org",

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,12 @@ def requirements():
     requirements_list = []
     for requirement in open("requirements.txt").read().rsplit("\n"):
         if "python_version" in requirement:
-            if "> '3'" in requirement and int(sys.version_info[0]) is 3:
+            if "> '3'" in requirement and int(sys.version_info[0]) == 3:
                 try:
                     __import__(requirement.rsplit('==')[0])
                 except:
                     requirements_list.append(requirement.rsplit(';')[0])
-            elif "< '3'" in requirement and int(sys.version_info[0]) is 2:
+            elif "< '3'" in requirement and int(sys.version_info[0]) == 2:
                 try:
                     __import__(requirement.rsplit('==')[0])
                 except:

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -124,7 +124,7 @@
             SCADA. It would make a competitive edge compared to other scanner making it one of the bests.</p>
         <h2>Links</h2>
         <ul>
-            <li>GitHub <a href="https://github.com/zdresearch/OWASP-Nettacker" class="glyphicon glyphicon-link"></a></li>
+            <li>GitHub <a href="https://github.com/OWASP/Nettacker" class="glyphicon glyphicon-link"></a></li>
             <li>OWASP <a href="https://www.owasp.org/index.php/OWASP_Nettacker" class="glyphicon glyphicon-link"></a>
             </li>
         </ul>


### PR DESCRIPTION
#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [x] The code is both Python 2 and Python 3 compatible.
- [x] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [x] This Pull Request relates to only one issue or only one feature
- [x] I have referenced the corresponding issue number in my commit message
- [x] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
References in source code to old Github repository are replaced by new OWASP GitHub repository as mentioned in Issue #363 and a bit of code refactoring.  
#### Your development environment
- OS: `Ubuntu`
- OS Version: `18.04`
- Python Version: `3.6.9`
