### PR TITLE
Fixed some false positives in dir_scan module

### DIFF
--- a/lib/scan/dir/engine.py
+++ b/lib/scan/dir/engine.py
@@ -186,7 +186,7 @@ def start(target, users, passwds, ports, timeout_sec, thread_number, num, total,
             target = 'http://' + target
         nowh3r3 = target + "/ThisFileIs404"
         try:
-            r = SESSION.get(nowh3r3, verify=False, headers=user_agent, timeout=10)
+            r = SESSION.get(nowh3r3, verify=False, headers=user_agent, timeout=timeout_sec)
             length = len(r.text)
         except Exception:
             length = 0


### PR DESCRIPTION
Fixed #280 
Tried fixing dir_scan false positives by making a request to arbitary path which for sure gives 404 and storing the Content-Length of it. Using the difflib module, finding the similarity between the original request(From bruteforcing the path) and the request made for 404. If the ratio is greater than 0.95, then consider it as similar and skip it, else consider it

#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/zdresearch/OWASP-Nettacker/wiki/Developers#contribution-guidelines).
- [x] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [x] The code is both Python 2 and Python 3 compatible.
- [x] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [x] This Pull Request relates to only one issue or only one feature
- [x] I have referenced the corresponding issue number in my commit message
- [ ] I have added the relevant documentation.
- [x] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request

#### Your development environment
- OS: `Linux`
- OS Version: `Ubuntu 20.04`
- Python Version: `3.8`
