### PR TITLE
Update wp_plugins_small.py

### DIFF
--- a/lib/scan/wp_plugin/wp_plugins_small.py
+++ b/lib/scan/wp_plugin/wp_plugins_small.py
@@ -57,4 +57,4 @@ def wp_plugins():
             "yolink-search", "yt-audio-streaming-audio-from-youtube", "zingiri-web-shop", "zotpress",
             "zotpressinboundio-marketing", "woocommerce", "tablepress", "ultimate-member", "yoast", "ninja-forms",
             "wordfence", "elementor", "all-in-one-seo-pack", "contact-form-7", "easy-wp-smtp", "redux-framework",
-            "loginizer", "wp-file-manager", "sucuri-scanner", "ninja-forms"]
+            "loginizer", "wp-file-manager", "sucuri-scanner", "ninja-forms", "the-plus-addons-for-elementor-page-builder"]


### PR DESCRIPTION
adding the-plus-addons-for-elementor-page-builder due recent critical vulnerability CVE-2021-24175

#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [X] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [X] The code is both Python 2 and Python 3 compatible.
- [X] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [X] This Pull Request relates to only one issue or only one feature
- [X] I have referenced the corresponding issue number in my commit message
- [X] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
Adding critically vulnerable Wordress plugin the-plus-addons-for-elementor-page-builder to the small list of Nettacket WP Plugins for faster detection. Ref: CVE-2021-24175
--



#### Your development environment
- OS: `x`
- OS Version: `x`
- Python Version: `x`
