### PR TITLE
fix port_scan module which having scapy bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,7 @@ pyspf
 SQLAlchemy>=1.3.0
 canari==3.3.10
 py3DNS==3.2.1; python_version > '3'
-scapy-python3==0.26; python_version > '3'
 pyDNS==2.3.6; python_version < '3'
-scapy>=2.4.1; python_version < '3'
 censys==0.0.8
 six==1.15.0
 shodan==1.25.0
@@ -24,3 +22,4 @@ pycurl==7.43.0.5
 xmltodict==0.12.0
 rule==0.1.1
 mechanize==0.4.5
+scapy==2.4.5


### PR DESCRIPTION
#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [x] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [x] The code is both Python 2 and Python 3 compatible.
- [x] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [x] This Pull Request relates to only one issue or only one feature
- [x] I have referenced the corresponding issue number in my commit message
- [x] I have added the relevant documentation.
- [x] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
Scapy < 2.4.5 having a bug which leads to issue #398 which is now fixed in latest version 2.4.5 which i added in requirements.txt file. These changes tested on linux environment with below mentioned python versions and it works completely fine.

#### Your development environment
- OS: `Backbox`
- OS Version: `7.1`
- Python Version: `2.7.18`,`3.8.5`,`3.9.2`,`3.9.4`
