### PR TITLE
added wp-seopress plugin CVE-2021-34641

### DIFF
--- a/lib/scan/wp_plugin/wp_plugins_small.py
+++ b/lib/scan/wp_plugin/wp_plugins_small.py
@@ -57,4 +57,4 @@ def wp_plugins():
             "yolink-search", "yt-audio-streaming-audio-from-youtube", "zingiri-web-shop", "zotpress",
             "zotpressinboundio-marketing", "woocommerce", "tablepress", "ultimate-member", "yoast", "ninja-forms",
             "wordfence", "elementor", "all-in-one-seo-pack", "contact-form-7", "easy-wp-smtp", "redux-framework",
-            "loginizer", "wp-file-manager", "sucuri-scanner", "ninja-forms", "the-plus-addons-for-elementor-page-builder"]
+            "loginizer", "wp-file-manager", "sucuri-scanner", "ninja-forms", "the-plus-addons-for-elementor-page-builder", "wp-seopress"]


### PR DESCRIPTION
adding wp-seopress to the wp_plugin_scan module (small list of plugins) due to CVE-2021-34641 which was disclosed on 2021-08-17 (XSS in wp-seopress plugin allows site takeover)

