### PR TITLE
auto service discovery

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,16 @@ jobs:
         run: "docker run -e github_ci=true -v $(pwd):/usr/src/owaspnettacker --rm -i nettacker python nettacker.py
          -i 127.0.0.1 -u user1,user2 -p pass1,pass2 -m all -g 21,25,80,443 -t 1000 -T 3 -o out.csv"
 
+      - name: Test all modules command + check if it's finish successfully + csv
+        run: "docker run -e github_ci=true -v $(pwd):/usr/src/owaspnettacker --rm -i nettacker python nettacker.py
+          -i 127.0.0.1 -u user1,user2 -p pass1,pass2 -m all -g 21,25,80,443 -t 1000 -T 3 -o out.csv --skip-service-discovery"
+
       - name: Test all modules command + check if it's finish successfully + with graph + Persian
         run: "docker run -e github_ci=true -v $(pwd):/usr/src/owaspnettacker --rm -i nettacker python nettacker.py -i
          127.0.0.1 -L fa -u user1,user2 -p pass1,pass2 --profile all -g 21,25,80,443 -t 1000 -T 3
          --graph d3_tree_v2_graph -v"
+
+      - name: Test all modules command + check if it's finish successfully + with graph + Persian
+        run: "docker run -e github_ci=true -v $(pwd):/usr/src/owaspnettacker --rm -i nettacker python nettacker.py -i
+         127.0.0.1 -L fa -u user1,user2 -p pass1,pass2 --profile all -g 21,25,80,443 -t 1000 -T 3
+         --graph d3_tree_v2_graph -v --skip-service-discovery"

--- a/config.py
+++ b/config.py
@@ -117,6 +117,7 @@ def nettacker_user_application_config():
         "time_sleep_between_requests": 0.0,
         "scan_ip_range": False,
         "scan_subdomains": False,
+        "skip_service_discovery": False,
         "thread_per_host": 100,
         "parallel_module_scan": 1,
         "socks_proxy": None,

--- a/core/args_loader.py
+++ b/core/args_loader.py
@@ -260,6 +260,13 @@ def load_all_args():
         help=messages("subdomains"),
     )
     modules.add_argument(
+        "--skip-service-discovery",
+        action="store_true",
+        default=nettacker_global_configuration['nettacker_user_application_config']["skip_service_discovery"],
+        dest="skip_service_discovery",
+        help=messages("skip_service_discovery")
+    )
+    modules.add_argument(
         "-t",
         "--thread-per-host",
         action="store",

--- a/core/args_loader.py
+++ b/core/args_loader.py
@@ -3,6 +3,7 @@
 
 import argparse
 import sys
+import json
 
 from core.alert import write
 from core.alert import warn
@@ -610,7 +611,27 @@ def check_all_required(parser, api_forms=None):
     if options.modules_extra_args:
         all_args = {}
         for args in options.modules_extra_args.split("&"):
-            all_args[args.split('=')[0]] = args.split('=')[1]
+            value = args.split('=')[1]
+            if value.lower() == 'true':
+                value = True
+            elif value.lower() == 'false':
+                value = False
+            elif '.' in value:
+                try:
+                    value = float(value)
+                except Exception as _:
+                    del _
+            elif '{' in value or '[' in value:
+                try:
+                    value = json.loads(value)
+                except Exception as _:
+                    del _
+            else:
+                try:
+                    value = int(value)
+                except Exception as _:
+                    del _
+            all_args[args.split('=')[0]] = value
         options.modules_extra_args = all_args
     options.timeout = float(options.timeout)
     options.time_sleep_between_requests = float(options.time_sleep_between_requests)

--- a/core/args_loader.py
+++ b/core/args_loader.py
@@ -497,8 +497,8 @@ def check_all_required(parser, api_forms=None):
         die_failure(messages("scan_method_select"))
     if options.selected_modules:
         if options.selected_modules == 'all':
-            options.selected_modules = modules_list
-            del options.selected_modules['all']
+            options.selected_modules = list(set(modules_list.keys()))
+            options.selected_modules.remove('all')
         else:
             options.selected_modules = list(set(options.selected_modules.split(',')))
         for module_name in options.selected_modules:
@@ -512,8 +512,8 @@ def check_all_required(parser, api_forms=None):
         if not options.selected_modules:
             options.selected_modules = []
         if options.profiles == 'all':
-            options.selected_modules = modules_list
-            del options.selected_modules['all']
+            options.selected_modules = list(set(modules_list.keys()))
+            options.selected_modules.remove('all')
         else:
             options.profiles = list(set(options.profiles.split(',')))
             for profile in options.profiles:

--- a/core/load_modules.py
+++ b/core/load_modules.py
@@ -116,20 +116,21 @@ class NettackerModules:
                         else:
                             services[protocol] = [port]
             self.discovered_services = copy.deepcopy(services)
+            index_payload = 0
             for payload in copy.deepcopy(self.module_content['payloads']):
                 if payload['library'] not in self.discovered_services and \
                         payload['library'] in self.service_discovery_signatures:
-                    del self.module_content['payloads'][self.module_content['payloads'].index(payload)]
+                    del self.module_content['payloads'][index_payload]
+                    index_payload -= 1
                 else:
+                    index_step = 0
                     for step in copy.deepcopy(
-                            self.module_content['payloads'][self.module_content['payloads'].index(payload)]['steps']
+                            self.module_content['payloads'][index_payload]['steps']
                     ):
-                        backup_step = copy.deepcopy(step)
                         step['ports'] = self.discovered_services[payload['library']]
-                        self.module_content['payloads'][self.module_content['payloads'].index(payload)]['steps'][
-                            self.module_content['payloads'][self.module_content['payloads'].index(payload)][
-                                'steps'].index(backup_step)
-                        ] = step
+                        self.module_content['payloads'][index_payload]['steps'][index_step] = step
+                        index_step += 1
+                index_payload += 1
 
     def generate_loops(self):
         from core.utility import expand_module_steps

--- a/core/load_modules.py
+++ b/core/load_modules.py
@@ -62,6 +62,10 @@ class NettackerModules:
         self.module_inputs = {}
         self.skip_service_discovery = None
         self.discovered_services = None
+        self.ignored_core_modules = [
+            'subdomain_scan',
+            'icmp_scan'
+        ]
         self.service_discovery_signatures = list(set(yaml.load(
             StringIO(
                 open(nettacker_paths()['modules_path'] + '/scan/port.yaml').read().format(
@@ -99,7 +103,7 @@ class NettackerModules:
             ),
             self.module_inputs
         )
-        if not self.skip_service_discovery:
+        if not self.skip_service_discovery and self.module_name not in self.ignored_core_modules:
             services = {}
             for service in find_events(self.target, 'port_scan', self.scan_unique_id):
                 service_event = json.loads(service.json_event)

--- a/core/load_modules.py
+++ b/core/load_modules.py
@@ -64,7 +64,8 @@ class NettackerModules:
         self.discovered_services = None
         self.ignored_core_modules = [
             'subdomain_scan',
-            'icmp_scan'
+            'icmp_scan',
+            'port_scan'
         ]
         self.service_discovery_signatures = list(set(yaml.load(
             StringIO(
@@ -127,7 +128,12 @@ class NettackerModules:
                     for step in copy.deepcopy(
                             self.module_content['payloads'][index_payload]['steps']
                     ):
-                        step['ports'] = self.discovered_services[payload['library']]
+                        find_and_replace_configuration_keys(
+                            step,
+                            {
+                                "ports": self.discovered_services[payload['library']]
+                            }
+                        )
                         self.module_content['payloads'][index_payload]['steps'][index_step] = step
                         index_step += 1
                 index_payload += 1

--- a/core/module_protocols/socket.py
+++ b/core/module_protocols/socket.py
@@ -76,10 +76,8 @@ class NettackerSocket:
         try:
             socket_connection.send(b"ABC\x00\r\n\r\n\r\n" * 10)
             response = socket_connection.recv(1024 * 1024 * 10)
-            print(response)
             socket_connection.close()
-        except Exception as e:
-            print(e)
+        except Exception:
             try:
                 socket_connection.close()
                 response = b""

--- a/core/module_protocols/socket.py
+++ b/core/module_protocols/socket.py
@@ -48,33 +48,38 @@ def create_tcp_socket(host, ports, timeout):
     socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     socket_connection.settimeout(timeout)
     socket_connection.connect((host, int(ports)))
+    ssl_flag = False
     try:
         socket_connection = ssl.wrap_socket(socket_connection)
+        ssl_flag = True
     except Exception:
         socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         socket_connection.settimeout(timeout)
         socket_connection.connect((host, int(ports)))
-    return socket_connection
+    return socket_connection, ssl_flag
 
 
 class NettackerSocket:
     def tcp_connect_only(host, ports, timeout):
-        socket_connection = create_tcp_socket(host, ports, timeout)
+        socket_connection, ssl_flag = create_tcp_socket(host, ports, timeout)
         peer_name = socket_connection.getpeername()
         socket_connection.close()
         return {
             "peer_name": peer_name,
-            "service": socket.getservbyport(int(ports))
+            "service": socket.getservbyport(int(ports)),
+            "ssl_flag": ssl_flag
         }
 
     def tcp_connect_send_and_receive(host, ports, timeout):
-        socket_connection = create_tcp_socket(host, ports, timeout)
+        socket_connection, ssl_flag = create_tcp_socket(host, ports, timeout)
         peer_name = socket_connection.getpeername()
         try:
-            socket_connection.send(b"ABC\x00\r\n" * 10)
+            socket_connection.send(b"ABC\x00\r\n\r\n\r\n" * 10)
             response = socket_connection.recv(1024 * 1024 * 10)
+            print(response)
             socket_connection.close()
-        except Exception:
+        except Exception as e:
+            print(e)
             try:
                 socket_connection.close()
                 response = b""
@@ -83,7 +88,8 @@ class NettackerSocket:
         return {
             "peer_name": peer_name,
             "service": socket.getservbyport(int(ports)),
-            "response": response.decode(errors='ignore')
+            "response": response.decode(errors='ignore'),
+            "ssl_flag": ssl_flag
         }
 
     def socket_icmp(host, timeout):
@@ -219,7 +225,8 @@ class NettackerSocket:
         socket_connection.close()
         return {
             "host": host,
-            "response_time": delay
+            "response_time": delay,
+            "ssl_flag": False
         }
 
 
@@ -260,6 +267,7 @@ class Engine:
                 response = []
         sub_step['method'] = backup_method
         sub_step['response'] = backup_response
+        sub_step['response']['ssl_flag'] = response['ssl_flag'] if type(response) == dict else False
         sub_step['response']['conditions_results'] = response_conditions_matched(sub_step, response)
         return process_conditions(
             sub_step,

--- a/core/targets.py
+++ b/core/targets.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import copy
 import json
+import os
 from core.ip import (get_ip_range,
                      generate_ip_range,
                      is_single_ipv4,
@@ -11,6 +12,13 @@ from core.ip import (get_ip_range,
                      is_ipv6_range,
                      is_ipv6_cidr)
 from database.db import find_events
+
+
+def filter_target_by_event(targets, scan_unique_id, module_name):
+    for target in copy.deepcopy(targets):
+        if not find_events(target, module_name, scan_unique_id):
+            targets.remove(target)
+    return targets
 
 
 def expand_targets(options, scan_unique_id):
@@ -24,7 +32,7 @@ def expand_targets(options, scan_unique_id):
     Returns:
         a generator
     """
-    from core.load_modules import perform_scan
+    from core.scan_targers import multi_processor
     targets = []
     for target in options.targets:
         if '://' in target:
@@ -40,35 +48,59 @@ def expand_targets(options, scan_unique_id):
         # IP ranges
         elif is_ipv4_range(target) or is_ipv6_range(target) or is_ipv4_cidr(target) or is_ipv6_cidr(target):
             targets += generate_ip_range(target)
-        # domains
-        elif options.scan_subdomains:
-            targets.append(target)
-            perform_scan(
-                options,
-                target,
-                'subdomain_scan',
-                scan_unique_id,
-                'pre_process',
-                'pre_process_thread',
-                'unknown'
-            )
-            for row in find_events(target, 'subdomain_scan', scan_unique_id):
-                for sub_domain in json.loads(row.json_event)['response']['conditions_results']['content']:
-                    if sub_domain not in targets:
-                        targets.append(sub_domain)
+        # domains probably
         else:
             targets.append(target)
+    options.targets = targets
+
+    # subdomain_scan
+    if options.scan_subdomains:
+        selected_modules = options.selected_modules
+        options.selected_modules = ['subdomain_scan']
+        multi_processor(
+            copy.deepcopy(options),
+            scan_unique_id
+        )
+        options.selected_modules = selected_modules
+        if 'subdomain_scan' in options.selected_modules:
+            options.selected_modules.remove('subdomain_scan')
+
+        for target in copy.deepcopy(options.targets):
+            for row in find_events(target, 'subdomain_scan', scan_unique_id):
+                for sub_domain in json.loads(row.json_event)['response']['conditions_results']['content']:
+                    if sub_domain not in options.targets:
+                        options.targets.append(sub_domain)
+    # icmp_scan
     if options.ping_before_scan:
-        for target in copy.deepcopy(targets):
-            perform_scan(
-                options,
-                target,
-                'icmp_scan',
-                scan_unique_id,
-                'pre_process',
-                'pre_process_thread',
-                'unknown'
+        if os.geteuid() == 0:
+            selected_modules = options.selected_modules
+            options.selected_modules = ['icmp_scan']
+            multi_processor(
+                copy.deepcopy(options),
+                scan_unique_id
             )
-            if not find_events(target, 'icmp_scan', scan_unique_id):
-                targets.remove(target)
-    return list(set(targets))
+            options.selected_modules = selected_modules
+            if 'icmp_scan' in options.selected_modules:
+                options.selected_modules.remove('icmp_scan')
+            options.targets = filter_target_by_event(targets, scan_unique_id, 'icmp_scan')
+        else:
+            from core.alert import warn
+            from core.alert import messages
+            warn(messages("icmp_need_root_access"))
+            if 'icmp_scan' in options.selected_modules:
+                options.selected_modules.remove('icmp_scan')
+    # port_scan
+    if not options.skip_service_discovery:
+        options.skip_service_discovery = True
+        selected_modules = options.selected_modules
+        options.selected_modules = ['port_scan']
+        multi_processor(
+            copy.deepcopy(options),
+            scan_unique_id
+        )
+        options.selected_modules = selected_modules
+        if 'port_scan' in options.selected_modules:
+            options.selected_modules.remove('port_scan')
+        options.targets = filter_target_by_event(targets, scan_unique_id, 'port_scan')
+        options.skip_service_discovery = False
+    return list(set(options.targets))

--- a/lib/messages/en.yaml
+++ b/lib/messages/en.yaml
@@ -10,6 +10,9 @@ API_key: " * API is accessible from https://nettacker-api.z3r0d4y.com:{0}/ via A
 API_options: API options
 API_port: API port number
 Method: Method
+skip_service_discovery: skip service discovery before scan and enforce all modules to scan anyway
+no_live_service_found: no any live service found to scan.
+icmp_need_root_access: to use icmp_scan module or --ping-before-scan you need to run the script as root!
 available_graph: "build a graph of all activities and information, you must use HTML output. available graphs: {0}"
 browser_session_killed: your browser session killed
 browser_session_valid: your browser session is valid

--- a/modules/scan/port.yaml
+++ b/modules/scan/port.yaml
@@ -1031,7 +1031,7 @@ payloads:
               regex: ""
               reverse: false
             http:
-              regex: "HTTP\\/[\\d.]+\\s+[\\d]+|Server: |Content-Length: \\d+|Content-Type: |Access-Control-Request-Headers: |Forwarded: |Proxy-Authorization: |User-Agent: |X-Forwarded-Host: |Content-MD5: |Access-Control-Request-Method: |Accept-Language: "
+              regex: "HTTPStatus.BAD_REQUEST|HTTP\\/[\\d.]+\\s+[\\d]+|Server: |Content-Length: \\d+|Content-Type: |Access-Control-Request-Headers: |Forwarded: |Proxy-Authorization: |User-Agent: |X-Forwarded-Host: |Content-MD5: |Access-Control-Request-Method: |Accept-Language: "
               reverse: false
             ftp:
               regex: "220-You are user number|530 USER and PASS required|Invalid command: try being more creative|220 \\S+ FTP (Service|service|Server|server)|220 FTP Server ready|Directory status|Service closing control connection|Requested file action|Connection closed; transfer aborted|Directory not empty"


### PR DESCRIPTION
Hi,

I implemented a similar feature we used to have in version 0.0.2 to ignore a port and send requests, e.g., HTTP if the port is not accepting the first request. this will save us a lot of time during a scan. For example, if a host doesn't have port 80 open, it won't keep trying and failing until the loop is finished. So instead, it will ignore the payload(if it's HTTP) (or any other payload such as ssh or whatever).

There is also a new feature if it discovers a known service (such as HTTP) in service discovery and our protocol exists in the framework. It will automatically rewrite and enforce the port and scan that service with relevant payloads. For instance, if there is an HTTP service on port 5000, and default HTTP ports are set as 80 and 443, it will automatically add 5000 (and remove 80 and 443 if they are not open). This also added a lot of value in saving time and benefits us during scans.

This service is relayed on port_scan, which means all targets will be automatically port_scan unless you use the `--skip-service-discovery` switch.

If a service didn't recognize during port_scan (HTTP signature was unknown), it would not be scanned, which pushes us to improve our signature-based service scan in the future.

During service discovery or `--ping-before-scan`, if you choose `port_scan` or `icmp_scan` module, they will be ignored as scan modules because we will use them in service discovery you will see the results in the reports anyway.

This also means if you want to check for an exploit on port 8080, you don't have to enter `-g 8080`, once the target port has been discovered, it will be automatically rewriting the ports in the modules, if you face issues with the discovery, use `--skip-service-discovery -g 8080` to enforce the scan.

@securestep9 @aman566 @itsdivyanshjain  please give this a review and test if you have time. It got a bit complicated and might cause a bug.

Let me know if you have any questions.

Bests, Ali.
