### PR TITLE
Added miniorange-login-openid to wp_plugin_small

### DIFF
--- a/lib/payloads/wordlists/wp_plugin_small.txt
+++ b/lib/payloads/wordlists/wp_plugin_small.txt
@@ -123,6 +123,7 @@ mailz
 media-library-categories
 meenews
 mingle-forum
+miniorange-login-openid
 mm-forms-community
 myflash
 mystat


### PR DESCRIPTION
Ddded miniorange-login-openid to support detection of Wordpress CVE-2023-2982 (CVSS 9.8 Critical) in WordPress Social Login and Register plugin

#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [X] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [X] The code is Python 3 compatible.
- [X] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [X] This Pull Request relates to only one issue or only one feature
- [ ] I have referenced the corresponding issue number in my commit message
- [ ] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request

Added miniorange-login-openid to wp_plugin_small to support detection of miniorange-login-openid Wordpress plugin which has vulnerability (https://github.com/advisories/GHSA-rx5f-42wm-7p9j) [CVE-2023-2982 CVSS 9.8 Critical]

#### Your development environment
- OS: `MacOS`
- OS Version: `12.6`
- Python Version: `3.11`
