### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.py linguist-detectable=true
+*.py linguist-language=Python
+*.html linguist-detectable=false


### PR DESCRIPTION
Re: issue #696  to stop GitHub from chowing Nettacker main language as HTML - it should be Python!

#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [X] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [X] The code is Python 3 compatible.
- [X] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [X] This Pull Request relates to only one issue or only one feature
- [X] I have referenced the corresponding issue number in my commit message
- [ ] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
adding .gitattributes file - it will be useful for many reasons, helping GitHub to marking the Nettacker repo as Python project (instead of HTML)


#### Your development environment
- OS: `macOS`
- OS Version: `12.6`
- Python Version: `3.11`
