### PR TITLE
Updated server_version_vuln module Server header logging

### DIFF
--- a/modules/vuln/server_version.yaml
+++ b/modules/vuln/server_version.yaml
@@ -39,3 +39,4 @@ payloads:
               server:
                 regex: .+\d*\.?\d\S+
                 reverse: false
+          log: "response_dependent['headers']['server']"


### PR DESCRIPTION
added logging of the server header - resolves #704 

#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [X] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [X] The code is Python 3 compatible.
- [X] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [X] This Pull Request relates to only one issue or only one feature
- [X] I have referenced the corresponding issue number in my commit message
- [X] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request

Updated server_version_vuln module to log the header

#### Your development environment
- OS: `macOS`
- OS Version: `12.06`
- Python Version: `3.11`
