### PR TITLE
Added new module, CVE_2023_6875

### DIFF
--- a/modules/vuln/wp_plugin_cve_2023_6875.yaml
+++ b/modules/vuln/wp_plugin_cve_2023_6875.yaml
@@ -1,0 +1,51 @@
+info:
+  name: wp_plugin_cve_2023_6875_vuln
+  author: Captain-T2004
+  severity: 9
+  description: POST SMTP Mailer – Email log, Delivery Failure Notifications and Best Mail SMTP for WordPress <= 2.8.7 – Unauthenticated Stored Cross-Site Scripting via device
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-6875
+    - https://www.wordfence.com/blog/2024/01/type-juggling-leads-to-two-vulnerabilities-in-post-smtp-mailer-wordpress-plugin/
+    - https://www.cve.org/CVERecord?id=CVE-2023-6875
+  profiles:
+    - vuln
+    - vulnerability
+    - http
+    - critical_severity
+    - cve2023
+    - cve
+    - wordpress
+    - wp_plugin
+
+payloads:
+  - library: http
+    steps:
+      - method: post
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/wp-json/post-smtp/v1/connect-app"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+        response:
+          success_conditions: content
+          condition_type: and
+          conditions:
+            content:
+              regex: "fcm_token"
+              reverse: false
+            status_code:
+              regex: "200"
+              reverse: false


### PR DESCRIPTION
#### Checklist
- [x] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [x] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [x] The code is Python 3 compatible.
- [x] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [x] This Pull Request relates to only one issue or only one feature
- [ ] I have referenced the corresponding issue number in my commit message
- [x] I have added the relevant documentation.
- [x] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
I have added a new module for a vuln module https://nvd.nist.gov/vuln/detail/CVE-2023-6875. This makes it possible for unauthenticated attackers to reset the API key used to authenticate to the mailer and view logs, including password reset emails, allowing site takeover.

```
python3 nettacker.py -i <target> -m wp_plugin_cve_2023_6875_vuln
```
#### Your development environment
- OS: `Pop!_OS 22.04 LTS`
- OS Version: `Linux pop-os 6.6.6-76060606-generic`
- Python Version: `3.10.12`
