### PR TITLE
New Module: HTML Title scan

### DIFF
--- a/modules/scan/http_html_title.yaml
+++ b/modules/scan/http_html_title.yaml
@@ -1,0 +1,44 @@
+info:
+  name: status_scan
+  author: OWASP Nettacker Team
+  severity: 3
+  description: HTTP Title scan
+  reference:
+  profiles:
+    - scan
+    - http
+    - backup
+    - low_severity
+
+payloads:
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        allow_redirects: true
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+        response:
+          condition_type: or
+          log: "response_dependent['status_code'] response_dependent['content']"
+          conditions:
+            status_code:
+                regex: \d\d\d
+                reverse: false
+            content:
+                regex: <title>(.+?)</title> 
+                reverse: false

--- a/modules/scan/http_html_title.yaml
+++ b/modules/scan/http_html_title.yaml
@@ -1,13 +1,12 @@
 info:
-  name: status_scan
+  name: http_html_title_scan
   author: OWASP Nettacker Team
   severity: 3
-  description: HTTP Title scan
+  description: HTTP HTML Title scan - extracts the TITLE tag which can help identify the application running on the server
   reference:
   profiles:
     - scan
     - http
-    - backup
     - low_severity
 
 payloads:


### PR DESCRIPTION
HTML Title scan module
#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [X] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [X] The code is Python 3 compatible.
- [ ] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [X] This Pull Request relates to only one issue or only one feature
- [ ] I have referenced the corresponding issue number in my commit message
- [X] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
New HTML Title scan module extracts the contents of the HTML <TITLE> tag on the target server, if present. This helps to identify what application is running on the server and is particularly useful when scanning networks and subdomains


#### Your development environment
- OS: `macOS`
- OS Version: `14.2`
- Python Version: `3.11`
