### PR TITLE
Ivanti ICS module fix: replaced hardcoded User-Agent with variable

### DIFF
--- a/modules/vuln/ivanti_ics_cve_2023_46805.yaml
+++ b/modules/vuln/ivanti_ics_cve_2023_46805.yaml
@@ -22,7 +22,7 @@ payloads:
       - method: get
         timeout: 3
         headers:
-          User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.138 Safari/537.36"
+          User-Agent: "{user_agent}"
         allow_redirects: false
         ssl: false
         url:
@@ -44,8 +44,8 @@ payloads:
           condition_type: and
           conditions:
             status_code:
-              regex: '403'
+              regex: "403"
               reverse: false
             content:
-              regex: '<html>'
+              regex: "<html>"
               reverse: true


### PR DESCRIPTION
Ivanti ICS module template fix: replaced hardcoded User-Agent with variable
#### Checklist
- [X] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [X] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [X] The code is Python 3 compatible.
- [ ] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [X] This Pull Request relates to only one issue or only one feature
- [ ] I have referenced the corresponding issue number in my commit message
- [ ] I have added the relevant documentation.
- [X] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
Ivanti ICS module template fix: replaced hardcoded User-Agent with variable
#### Your development environment
- OS: `macOS`
- OS Version: `14.2`
- Python Version: `3.11`
