### PR TITLE
Added More Command Examples for New Users in nettacker.py

### DIFF
--- a/nettacker.py
+++ b/nettacker.py
@@ -13,6 +13,26 @@ if __name__ == "__main__":
 
     # if dependencies and OS requirements are match then load the program
     from core.parse import load
+    import sys
 
-    load()  # load and parse the ARGV
+    # Example commands to demonstrate OWASP Nettacker functionalities
+    example_commands = [
+        "-i target.com",
+        "-i target.com -v --start-api --api-host 0.0.0.0 --api-port 5000",
+        "-i target.com -m ftp_brute,ssh_brute",
+        "-i target.com -o results.txt -L en",
+        "-i target.com -u admin -P passwords.txt",
+        "-i target.com -g 21,22 -p tcp,udp",
+        "-i target.com --start-api --api-host 192.168.1.100 --api-port 8080 --api-ssl",
+        "-i target.com -m http_crawl -f --crawl-depth 3",
+        "-i target.com --db-save --db-name nettacker_results"
+    ]
+
+    # Print example commands
+    print("Example commands:")
+    for command in example_commands:
+        print(f"nettacker {command}")
+
+    # Load and parse the ARGV
+    load()
     # sys.exit(main())


### PR DESCRIPTION
Fixes #740

#### Checklist
- [ ] I have followed the [Contributor Guidelines](https://github.com/OWASP/Nettacker/wiki/Developers#contribution-guidelines).
- [ ] The code has been thoroughly tested in my local development environment with flake8 and pylint.
- [ ] The code is Python 3 compatible.
- [ ] The code follows the PEP8 styling guidelines with 4 spaces indentation.
- [ ] This Pull Request relates to only one issue or only one feature
- [ ] I have referenced the corresponding issue number in my commit message
- [ ] I have added the relevant documentation.
- [ ] My branch is up-to-date with the Upstream master branch.

#### Changes proposed in this pull request
In your Python code (nettacker.py), consider adding more command examples. This helps new users who may find it difficult to create the right commands when they use your code for the first time. It makes it easier for them to write the correct code.

Like that:-

nettacker -L en -v -o results.txt -i target.com -m ftp_brute,ssh_brute -u admin -P passwords.txt -g 21,22 --start-api --api-host 0.0.0.0 --api-port 5000
