### PR TITLE
ScanID added to CLI and HTML report for easy identification of results

### DIFF
--- a/nettacker/core/app.py
+++ b/nettacker/core/app.py
@@ -205,7 +205,7 @@ class Nettacker(ArgParser):
         create_report(self.arguments, scan_id)
         if self.arguments.scan_compare_id is not None:
             create_compare_report(self.arguments, scan_id)
-        log.info("ScanID: {0} ".format(scan_id)+_("done"))
+        log.info("ScanID: {0} ".format(scan_id) + _("done"))
 
         return exit_code
 

--- a/nettacker/core/app.py
+++ b/nettacker/core/app.py
@@ -193,7 +193,7 @@ class Nettacker(ArgParser):
             True when it ends
         """
         scan_id = utils.generate_random_token(32)
-
+        log.info("ScanID: {0}".format(scan_id))
         log.info(_("regrouping_targets"))
         # find total number of targets + types + expand (subdomain, IPRanges, etc)
         # optimize CPU usage
@@ -201,12 +201,11 @@ class Nettacker(ArgParser):
         if not self.arguments.targets:
             log.info(_("no_live_service_found"))
             return True
-
         exit_code = self.start_scan(scan_id)
         create_report(self.arguments, scan_id)
         if self.arguments.scan_compare_id is not None:
             create_compare_report(self.arguments, scan_id)
-        log.info(_("done"))
+        log.info("ScanID: {0} ".format(scan_id)+_("done"))
 
         return exit_code
 

--- a/nettacker/core/graph.py
+++ b/nettacker/core/graph.py
@@ -175,6 +175,7 @@ def create_report(options, scan_id):
             + "</div>"
             + '<p class="footer">'
             + _("nettacker_version_details").format(version_info()[0], version_info()[1], now())
+            + " ScanID: {0}".format(scan_id)
             + "</p>"
             + log_data.json_parse_js
         )


### PR DESCRIPTION
ScanID output added to the CLI scan start up and completion messaging and the HTML report footer for the easy identification of the results belonging to a specific scan and for scan comparison purposes
