### PR TITLE
Updated wp_plugin_small.txt with the-events-calendar (CVE-2024-8275)

### DIFF
--- a/nettacker/lib/payloads/wordlists/wp_plugin_small.txt
+++ b/nettacker/lib/payloads/wordlists/wp_plugin_small.txt
@@ -189,6 +189,7 @@ stats
 store-locator-le
 subscribe-to-comments
 tagninja
+the-events-calendar
 the-welcomizer
 thecartpress
 thinkun-remind


### PR DESCRIPTION
Added  the-events-calendar to the list as it has Unauthenticated SQL Injection vulnerability (SQLi) CVE-2024-8275
