### PR TITLE
Fix code scanning alert no. 28: Uncontrolled data used in path expression

### DIFF
--- a/nettacker/api/core.py
+++ b/nettacker/api/core.py
@@ -117,15 +117,16 @@ def get_file(filename):
     Returns:
         content of the file or abort(404)
     """
-    if not os.path.normpath(filename).startswith(str(Config.path.web_static_dir)):
+    base_path = str(Config.path.web_static_dir)
+    fullpath = os.path.normpath(os.path.join(base_path, filename))
+    if not fullpath.startswith(base_path):
         abort(404)
     try:
-        return open(filename, "rb").read()
+        return open(fullpath, "rb").read()
     except ValueError:
         abort(404)
     except IOError:
         abort(404)
-
 
 def api_key_is_valid(app, flask_request):
     """


### PR DESCRIPTION
Fixes [https://github.com/OWASP/Nettacker/security/code-scanning/28](https://github.com/OWASP/Nettacker/security/code-scanning/28)

To fix the problem, we need to ensure that the `filename` parameter is securely validated before being used to access the file system. The best way to do this is to:
1. Normalize the path to remove any relative path components.
2. Ensure that the resulting path is within the intended directory by comparing the common prefix of the normalized path and the base directory.

We will modify the `get_file` function to include these steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
