### PR TITLE
Adding litespeed-cache to wp_plugin_small.txt

### DIFF
--- a/nettacker/lib/payloads/wordlists/wp_plugin_small.txt
+++ b/nettacker/lib/payloads/wordlists/wp_plugin_small.txt
@@ -115,6 +115,7 @@ lazyest-gallery
 leaguemanager
 like-dislike-counter-for-posts-pages-and-comments
 link-library
+litespeed-cache
 lisl-last-image-slider
 livesig
 login-lockdown


### PR DESCRIPTION
Adding litespeed-cache plugin affected by CVE-2024-47374 to the list of WordPress plugins to scan for. Ref: https://thehackernews.com/2024/10/wordpress-litespeed-cache-plugin.html
