### PR TITLE
Update wp_plugin_small.txt: chart-builder & happy-elementor-addons

### DIFF
--- a/nettacker/lib/payloads/wordlists/wp_plugin_small.txt
+++ b/nettacker/lib/payloads/wordlists/wp_plugin_small.txt
@@ -285,3 +285,5 @@ the-plus-addons-for-elementor-page-builder
 wp-seopress
 media-library-assistant
 forminator
+happy-elementor-addons
+chart-builder


### PR DESCRIPTION
Adding happy-elementor-addons and chart-builder to the wordpress plugin list due to the latest CVEs:  CVE-2024-10538(Stored XSS)  & CVE-2024-10571 (Unauth LFI)
