### PR TITLE
Update wp_plugin_small.txt Add: really-simple-ssl

### DIFF
--- a/nettacker/lib/payloads/wordlists/wp_plugin_small.txt
+++ b/nettacker/lib/payloads/wordlists/wp_plugin_small.txt
@@ -287,3 +287,4 @@ media-library-assistant
 forminator
 happy-elementor-addons
 chart-builder
+really-simple-ssl


### PR DESCRIPTION
Adding  'really-simple-ssl' Wordpress plugin to the list of plugins detected by Nettacker to help identify Wordpress sites vulnerable to CVE-2024-10924
