### PR TITLE
Fixes open port print in port_scan module.

### DIFF
--- a/nettacker/core/lib/socket.py
+++ b/nettacker/core/lib/socket.py
@@ -233,10 +233,12 @@ class SocketEngine(BaseEngine):
             return response
         if sub_step["method"] == "tcp_connect_send_and_receive":
             if response:
-                received_content = response["response"]
                 for condition in conditions:
                     regex = re.findall(
-                        re.compile(conditions[condition]["regex"]), received_content
+                        re.compile(conditions[condition]["regex"]),
+                        response["response"]
+                        if condition != "open_port"
+                        else str(response["peer_name"][1]),
                     )
                     reverse = conditions[condition]["reverse"]
                     condition_results[condition] = reverse_and_regex_condition(regex, reverse)

--- a/nettacker/modules/scan/port.yaml
+++ b/nettacker/modules/scan/port.yaml
@@ -1028,7 +1028,7 @@ payloads:
           condition_type: or
           conditions:
             open_port:
-              regex: ""
+              regex: \d{{1,5}}
               reverse: false
 
             ftp: &ftp

--- a/tests/core/lib/test_socket.py
+++ b/tests/core/lib/test_socket.py
@@ -9,6 +9,10 @@ class Responses:
 
     tcp_connect_send_and_receive = {
         "response": 'HTTP/1.1 400 Bad Request\r\nServer: Apache/2.4.62 (Debian)\r\nContent-Length: 302\r\nConnection: close\r\nContent-Type: text/html; charset=iso-8859-1\r\n\r\n<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">\n<html><head>\n<title>400 Bad Request</title>\n</head><body>\n<h1>Bad Request</h1>\n<p>Your browser sent a request that this server could not understand.<br />\n</p>\n<hr>\n<address>Apache/2.4.62 (Debian)</address>\n</body></html>\n',
+        "peer_name": (
+            "127.0.0.1",
+            80,
+        ),
         "ssl_flag": True,
     }
 


### PR DESCRIPTION
This PR fixes found open port printing problem in port_scan module output.
it is printing like this

conditions: open_port: - ''

after that fix, it is

conditions: open_port: - '443'


- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
