### PR TITLE
Fixes SSL connection issues with python 3.12

### DIFF
--- a/nettacker/core/lib/ssl.py
+++ b/nettacker/core/lib/ssl.py
@@ -1,6 +1,7 @@
 import logging
 import socket
 import ssl
+import sys
 from datetime import datetime, timezone
 
 from OpenSSL import crypto
@@ -117,7 +118,12 @@ def create_tcp_socket(host, port, timeout):
         return None
 
     try:
-        socket_connection = ssl.wrap_socket(socket_connection)
+        if sys.version_info >= (3, 12):
+            socket_connection = ssl.create_default_context().wrap_socket(
+                socket_connection, server_hostname=host
+            )
+        else:
+            socket_connection = ssl.wrap_socket(socket_connection)
         ssl_flag = True
     except Exception:
         socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/core/lib/test_ssl.py
+++ b/tests/core/lib/test_ssl.py
@@ -1,4 +1,5 @@
 import ssl
+import sys
 from unittest.mock import patch
 
 from nettacker.core.lib.ssl import (
@@ -153,7 +154,7 @@ class Substeps:
 
 class TestSocketMethod(TestCase):
     @patch("socket.socket")
-    @patch("ssl.wrap_socket")
+    @patch("ssl.SSLContext.wrap_socket" if sys.version_info >= (3, 12) else "ssl.wrap_socket")
     def test_create_tcp_socket(self, mock_wrap, mock_socket):
         HOST = "example.com"
         PORT = 80
@@ -163,7 +164,10 @@ class TestSocketMethod(TestCase):
         socket_instance = mock_socket.return_value
         socket_instance.settimeout.assert_called_with(TIMEOUT)
         socket_instance.connect.assert_called_with((HOST, PORT))
-        mock_wrap.assert_called_with(socket_instance)
+        if sys.version_info >= (3, 12):
+            mock_wrap.assert_called_with(socket_instance, server_hostname=HOST)
+        else:
+            mock_wrap.assert_called_with(socket_instance)
 
     @patch("nettacker.core.lib.ssl.is_weak_cipher_suite")
     @patch("nettacker.core.lib.ssl.is_weak_ssl_version")


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR fixes for SSL connection wrap issue which is happening with Python 3.12. It was deprecated 3.7 and now removed.
## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
