### PR TITLE
added the hit URLs to the output log for admin_scan, keeping other functionality the same

### DIFF
--- a/nettacker/core/graph.py
+++ b/nettacker/core/graph.py
@@ -83,8 +83,9 @@ def build_text_table(events):
     _table = texttable.Texttable()
     table_headers = ["date", "target", "module_name", "port", "logs"]
     _table.add_rows([table_headers])
+
     for event in events:
-        log = merge_logs_to_list(json.loads(event["json_event"]), [])
+        log = merge_logs_to_list(json.loads(event["json_event"]), [], event["module_name"])
         _table.add_rows(
             [
                 table_headers,

--- a/nettacker/core/utils/common.py
+++ b/nettacker/core/utils/common.py
@@ -30,15 +30,27 @@ def replace_dependent_response(log, response_dependent):
         return log
 
 
-def merge_logs_to_list(result, log_list=[]):
+def merge_logs_to_list(result, log_list=[], module_name=''):
     if isinstance(result, dict):
-        for i in result:
-            if "log" == i:
-                log_list.append(result["log"])
-            else:
-                merge_logs_to_list(result[i], log_list)
-    return list(set(log_list))
+        if "admin_scan" in module_name.strip():
+            for i in result:
+                # Things important in an admin scan
+                if "url" == i.strip() or "status_code" == i.strip():
+                    print(i)
+                    if "url" == i.strip():
+                        log_list.append(f'URL: {result[i]} \n')
+                    else:
+                        log_list.append(f"status_code: {result[i]} \n")
+                else:
+                    merge_logs_to_list(result[i], log_list)
+        else:
+            for i in result:
+                if "log" == i:
+                    log_list.append(result["log"])
+                else:
+                    merge_logs_to_list(result[i], log_list)
 
+    return list(set(log_list))
 
 def reverse_and_regex_condition(regex, reverse):
     if regex:


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

Adding the directories hit and the status codes to the output table shown to the user in case of `admin_scans`. Related to issue #1004. I have not changed the HTML, JSON or CSV outputs yet. 

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->


## Type of change

`admin_scan` doesn't return a 'log' key and hence its not present inside 'results' leading to it only showing `detected` for admin scans which is not very helpful. So, this PR is to just fix that for admin scans.

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->