### PR TITLE
added argument to take in base path for the URL supplied for directory enumeration

### DIFF
--- a/nettacker/config.py
+++ b/nettacker/config.py
@@ -131,6 +131,7 @@ class DefaultSettings(ConfigBase):
     show_all_profiles = False
     show_help_menu = False
     show_version = False
+    url_base_path = None
     skip_service_discovery = False
     socks_proxy = None
     targets = None

--- a/nettacker/core/app.py
+++ b/nettacker/core/app.py
@@ -170,6 +170,11 @@ class Nettacker(ArgParser):
             self.arguments.selected_modules = selected_modules
             if "port_scan" in self.arguments.selected_modules:
                 self.arguments.selected_modules.remove("port_scan")
+
+            if self.arguments.url_base_path:
+                for ind, target in enumerate(targets):
+                    targets[ind] += self.arguments.url_base_path
+
             self.arguments.targets = self.filter_target_by_event(targets, scan_id, "port_scan")
             self.arguments.skip_service_discovery = False
 

--- a/nettacker/core/arg_parser.py
+++ b/nettacker/core/arg_parser.py
@@ -400,6 +400,14 @@ class ArgParser(ArgumentParser):
             help=_("compare_scans"),
         )
         method_options.add_argument(
+            "-B",
+            "--base-path",
+            action="store",
+            dest="url_base_path",
+            default=Config.settings.url_base_path,
+            help=_("url_base_path"),
+        )
+        method_options.add_argument(
             "-J",
             "--compare-report-path",
             action="store",
@@ -684,7 +692,16 @@ class ArgParser(ArgumentParser):
             ):
                 log.warn(_("graph_output"))
                 options.graph_name = None
-        # check modules extra args
+        # check base path
+        if options.url_base_path:
+            if options.url_base_path.startswith('/'):
+                for target in options.targets:
+                    log.info(_("starting_with_base_path").format(target, str(options.url_base_path)))
+            else:
+                updated_base_path = f"/{options.url_base_path}"
+                for target in options.targets:
+                    log.info(_("starting_with_base_path").format(target, updated_base_path))
+        # check modules extra args 
         if options.modules_extra_args:
             all_args = {}
             for args in options.modules_extra_args.split("&"):

--- a/nettacker/core/arg_parser.py
+++ b/nettacker/core/arg_parser.py
@@ -694,14 +694,16 @@ class ArgParser(ArgumentParser):
                 options.graph_name = None
         # check base path
         if options.url_base_path:
-            if options.url_base_path.startswith('/'):
+            if options.url_base_path.startswith("/"):
                 for target in options.targets:
-                    log.info(_("starting_with_base_path").format(target, str(options.url_base_path)))
+                    log.info(
+                        _("starting_with_base_path").format(target, str(options.url_base_path))
+                    )
             else:
                 updated_base_path = f"/{options.url_base_path}"
                 for target in options.targets:
                     log.info(_("starting_with_base_path").format(target, updated_base_path))
-        # check modules extra args 
+        # check modules extra args
         if options.modules_extra_args:
             all_args = {}
             for args in options.modules_extra_args.split("&"):

--- a/nettacker/core/lib/base.py
+++ b/nettacker/core/lib/base.py
@@ -120,6 +120,9 @@ class BaseEngine(ABC):
         request_number_counter,
         total_number_of_requests,
     ):
+        if options.get("url_base_path"):
+            target = target + options.get("url_base_path")
+            
         if "save_to_temp_events_only" in event.get("response", ""):
             submit_temp_logs_to_db(
                 {

--- a/nettacker/core/lib/base.py
+++ b/nettacker/core/lib/base.py
@@ -122,7 +122,7 @@ class BaseEngine(ABC):
     ):
         if options.get("url_base_path"):
             target = target + options.get("url_base_path")
-            
+
         if "save_to_temp_events_only" in event.get("response", ""):
             submit_temp_logs_to_db(
                 {

--- a/nettacker/locale/en.yaml
+++ b/nettacker/locale/en.yaml
@@ -123,3 +123,5 @@ no_scan_to_compare: the scan_id to be compared not found
 compare_report_saved: "compare results saved in {0}"
 build_compare_report: "building compare report"
 finish_build_report: "Finished building compare report"
+url_base_path: set the base path (as "/pathname") to start enumeration from
+starting_with_base_path: "Scanning {0} with base directory: {1}"

--- a/nettacker/modules/scan/dir.yaml
+++ b/nettacker/modules/scan/dir.yaml
@@ -21,7 +21,7 @@ payloads:
         ssl: false
         url:
           nettacker_fuzzer:
-            input_format: "{{schema}}://{target}:{{ports}}/{{urls}}/"
+            input_format: "{{schema}}://{target}/{{urls}}/"
             prefix: ""
             suffix: ""
             interceptors:
@@ -31,9 +31,6 @@ payloads:
               schema:
                 - "http"
                 - "https"
-              ports:
-                - 80
-                - 443
         response:
           condition_type: and
           log: "response_dependent['url']"          


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR is to fix the issue described in #1009. Earlier running the following command

```sh
python3 nettacker.py -i https://test_website_name.com/test_dir -m dir_scan
```
would result in a directory enumeration starting not from `/test_dir` but from `https://test_website_name.com/` itself. This was not desired because a most of the times paths are stacked.

With the added parser the user can type in the following command to ensure a proper enumeration

```sh
python3 nettacker.py -i https://test_website_name.com -m dir_scan -B "/test_dir"
```
In this case, the names present in the dir_wordlist build on top the `test_dir`.

I have removed the port option from dir_scan because the `http` and `https` schema do not need that. (other than that, I have ensured that I don't mess with any core functionality)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [x] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

