### PR TITLE
Fix: Make OS path logic OS-agnostic using pathlib

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))  # Ensure tests/ is in sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))  # Ensure project root is in sys.path
+

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,9 +1,0 @@
-import unittest
-from pathlib import Path
-
-from conftest import nettacker_dir, tests_dir
-
-
-class TestCase(unittest.TestCase):
-    nettacker_path = Path(nettacker_dir)
-    tests_path = Path(tests_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import sys
-from os.path import abspath, dirname, join
+from pathlib import Path
 
-project_root = dirname(dirname(__file__))
-nettacker_dir = abspath(join(project_root, "src/nettacker"))
-tests_dir = abspath(join(project_root, "tests"))
+project_root = Path(__file__).resolve().parent.parent
+nettacker_dir = project_root / "src" / "nettacker"
+tests_dir = project_root / "tests"
 
-sys.path.insert(0, nettacker_dir)
-sys.path.insert(1, tests_dir)
+sys.path.insert(0, str(nettacker_dir))
+sys.path.insert(1, str(tests_dir))

--- a/tests/lib/payloads/test_passwords.py
+++ b/tests/lib/payloads/test_passwords.py
@@ -1,16 +1,16 @@
 from collections import Counter
-
 import pytest
-
-from tests.common import TestCase
-
+from tests.test_common import TestCase
 
 class TestPasswords(TestCase):
-    top_1000_common_passwords_path = "lib/payloads/passwords/top_1000_common_passwords.txt"
+
+    def setUp(self):
+        super().setUp()  # Call parent setup to ensure nettacker_path is set
+        self.top_1000_common_passwords_path = self.nettacker_path / "lib" / "payloads" / "passwords" / "top_1000_common_passwords.txt"
 
     @pytest.mark.xfail(reason="It currently contains 1001 passwords.")
     def test_top_1000_common_passwords(self):
-        with open(self.nettacker_path / self.top_1000_common_passwords_path) as top_1000_file:
+        with open(self.top_1000_common_passwords_path) as top_1000_file:
             top_1000_passwords = [line.strip() for line in top_1000_file.readlines()]
 
         self.assertEqual(len(top_1000_passwords), 1000, "There should be exactly 1000 passwords")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        # Fix the paths
+        self.project_root = Path(__file__).resolve().parent.parent  # Go up from 'tests'
+        self.nettacker_path = self.project_root / "nettacker"  # Correct location
+        self.tests_path = self.project_root / "tests"
+
+        # Debugging information
+        print(f"DEBUG: Expected nettacker_path: {self.nettacker_path}")
+        print(f"DEBUG: Expected tests_path: {self.tests_path}")
+
+    def test_paths_exist(self):
+        # Check if paths exist
+        self.assertTrue(self.nettacker_path.exists(), f"Nettacker directory does not exist: {self.nettacker_path}")
+        self.assertTrue(self.tests_path.exists(), f"Tests directory does not exist: {self.tests_path}")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
