### PR TITLE
updated regex for SSH scanning to include more matches

### DIFF
--- a/nettacker/modules/scan/port.yaml
+++ b/nettacker/modules/scan/port.yaml
@@ -1083,7 +1083,7 @@ payloads:
               reverse: false
 
             ssh:
-              regex: "openssh|\\-OpenSSH\\_|\\r\\nProtocol mism|\\_sshlib|\\x00\\x1aversion info line too long|SSH Windows NT Server|WinNT sshd|sshd| SSH Secure Shell|WinSSHD"
+              regex: "openssh|\\-OpenSSH\\_|\\r?\\n?Protocol mism|\\_sshlib|\\x00\\x1aversion info line too long|SSH Windows NT Server|WinNT sshd|sshd| SSH Secure Shell|WinSSHD|SSH-[\\d.]+-[A-Za-z0-9_\\-]+|SSH-[\\d.]+\\r?\\n?"
               reverse: false
 
             telnet:


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

The current regex for SSH port matching is correct for matching banners from Ubuntu, Debian, FreeBSD SSH banners, however a lot of services have SSH banners that are like this

`SSH-2.0-ad34f3baf` 

For example, running the following reveals the same for github.com,
`nc -v github.com 22`

Thus, to match these as well, I have updated the regex. 
<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->
## Additional info

Future work includes creating NULL probes to capture banners of services that reveal it without any explicit probing (like SSH, FTP) along with the arbitrary probe that is currently defined.
