### PR TITLE
added time delay between requests to run parallel module scans

### DIFF
--- a/nettacker/config.py
+++ b/nettacker/config.py
@@ -136,7 +136,7 @@ class DefaultSettings(ConfigBase):
     targets = None
     targets_list = None
     thread_per_host = 100
-    time_sleep_between_requests = 0.0
+    time_sleep_between_requests = 0.05
     timeout = 3.0
     user_agent = "Nettacker {version_number} {version_code}".format(
         version_number=version_info()[0], version_code=version_info()[1]


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->
Fix for issue #616. The issue is likely happening due to race conditions with python's garbage collector trying to delete a loop that's running causing the `BaseEventLoop.__del__` exception, which causes the _sock exception. The simple fix for this is to give a small delay to in between each request to let threads finish execution and let python handle the deletion properly.

If we run the following command with this change,

```bash
 python3 nettacker.py -i google.com --profile http -t 1100 -M 5
```
We get the complete output without errors. It should also be noted that the delay doesn't cause problems in parallel execution because we only delay threads. Using `await asyncio.sleep()` also won't matter much because there are no async tasks to handle control to. 

Additionally, since its the CPU handling the threads, with time.sleep() it removes the asleep thread from the queue, hence sleep here won't block execution for other threads.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->
