### PR TITLE
Removing redundancy and cleaning profiles

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -375,7 +375,7 @@ python nettacker.py -i 192.168.1.1/24 -m *_scan,*_vuln
 
 ```
 python nettacker.py -i 192.168.1.1/24 --profile info
-python nettacker.py -i 192.168.1.1/24 --profile info,vulnerabilities
+python nettacker.py -i 192.168.1.1/24 --profile info,vuln
 python nettacker.py -i 192.168.1.1/24 --profile all
 ```
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -81,7 +81,7 @@ Method:
                         add extra args to pass to modules (e.g. --modules-extra-args "x_api_key=123&xyz_passwd=abc"
   --show-all-modules    show all modules and their information
   --profile PROFILES    select profile ['accela', 'adobe', 'apache', 'apache_ofbiz', 'apache_struts', 'atlassian',
-                        'aviatrix', 'backup', 'brute', 'brute_force']
+                        'aviatrix', 'backup', 'brute']
   --show-all-profiles   show all profiles and their information
   -x EXCLUDED_MODULES, --exclude-modules EXCLUDED_MODULES
                         choose scan method to exclude ['accela_cve_2021_34370_vuln', 'admin_scan',
@@ -229,7 +229,7 @@ usage: Nettacker [-L LANGUAGE] [-v] [--verbose-event] [-V] [-o REPORT_PATH_FILEN
                         add extra args to pass to modules (e.g. --modules-extra-args "x_api_key=123&xyz_passwd=abc"
   --show-all-modules    show all modules and their information
   --profile PROFILES    انتخاب پروفایل ['accela', 'adobe', 'apache', 'apache_ofbiz', 'apache_struts', 'atlassian',
-                        'aviatrix', 'backup', 'brute', 'brute_force']
+                        'aviatrix', 'backup', 'brute']
   --show-all-profiles   show all profiles and their information
   -x EXCLUDED_MODULES, --exclude-modules EXCLUDED_MODULES
                         انتخاب متود اسکن استثنا ['accela_cve_2021_34370_vuln', 'admin_scan',
@@ -374,8 +374,8 @@ python nettacker.py -i 192.168.1.1/24 -m *_scan,*_vuln
 * Use profiles for using all modules inside a given profile
 
 ```
-python nettacker.py -i 192.168.1.1/24 --profile information_gathering
-python nettacker.py -i 192.168.1.1/24 --profile information_gathering,vulnerabilities
+python nettacker.py -i 192.168.1.1/24 --profile info
+python nettacker.py -i 192.168.1.1/24 --profile info,vulnerabilities
 python nettacker.py -i 192.168.1.1/24 --profile all
 ```
 
@@ -411,43 +411,43 @@ python nettacker.py --show-all-modules
 
 
 
-[2021-08-31 17:42:06][+] http_options_enabled_vuln: name: http_options_enabled_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity']
-[2021-08-31 17:42:06][+] clickjacking_vuln: name: clickjacking_vuln, author: OWASP Nettacker Team, severity: 5, description: Clickjacking, also known as a "UI redress attack", is when an attacker uses multiple transparent or opaque layers to trick a user into clicking on a button, reference: https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html, profiles: ['vuln', 'vulnerability', 'http', 'medium_severity']
-[2021-08-31 17:42:06][+] wp_xmlrpc_bruteforce_vuln: name: wp_xmlrpc_bruteforce_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity', 'wordpress', 'wp']
-[2021-08-31 17:42:06][+] graphql_vuln: name: graphql_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'information_gathering', 'http', 'low_severity', 'graphql']
-[2021-08-31 17:42:06][+] content_security_policy_vuln: name: content_security_policy_vuln, author: OWASP Nettacker Team, severity: 3, description: Content-Security-Policy is the name of a HTTP response header that modern browsers use to enhance the security of the document (or web page). The Content-Security-Policy header allows you to restrict how resources such as JavaScript, CSS, or pretty much anything that the browser loads., reference: https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html, profiles: ['vuln', 'vulnerability', 'http', 'low_severity', 'csp']
-[2021-08-31 17:42:06][+] xdebug_rce_vuln: name: xdebug_rce_vuln, author: OWASP Nettacker Team, severity: 10, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'critical_severity']
-[2021-08-31 17:42:06][+] x_powered_by_vuln: name: x_powered_by_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity']
-[2021-08-31 17:42:06][+] wp_xmlrpc_pingback_vuln: name: wp_xmlrpc_pingback_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'wordpress', 'wp']
-[2021-08-31 17:42:06][+] http_cors_vuln: name: http_cors_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity']
-[2021-08-31 17:42:06][+] f5_cve_2020_5902_vuln: name: f5_cve_2020_5902_vuln, author: OWASP Nettacker Team, severity: 9, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'critical_severity', 'cve', 'f5']
-[2021-08-31 17:42:06][+] subdomain_takeover_vuln: name: subdomain_takeover_vuln, author: OWASP Nettacker Team, severity: 5, description: let us assume that example.com is the target and that the team running example.com have a bug bounty programme. While enumerating all of the subdomains belonging to example.com — a process that we will explore later — a hacker stumbles across subdomain.example.com, a subdomain pointing to GitHub pages. We can determine this by reviewing the subdomain's DNS records; in this example, subdomain.example.com has multiple A records pointing to GitHub's dedicated IP addresses for custom pages., reference: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover, profiles: ['vuln', 'vulnerability', 'http', 'medium_severity', 'takeover']
-[2021-08-31 17:42:06][+] http_trace_enabled_vuln: name: http_trace_enabled_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity']
-[2021-08-31 17:42:06][+] http_cookie_vuln: name: http_cookie_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity']
-[2021-08-31 17:42:06][+] wp_xmlrpc_dos_vuln: name: wp_xmlrpc_dos_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'wordpress', 'wp']
-[2021-08-31 17:42:06][+] server_version_vuln: name: server_version_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity']
-[2021-08-31 17:42:06][+] x_xss_protection_vuln: name: x_xss_protection_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity']
-[2021-08-31 17:42:06][+] citrix_cve_2019_19781_vuln: name: citrix_cve_2019_19781_vuln, author: OWASP Nettacker Team, severity: 8, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'high_severity', 'cve', 'citrix']
-[2021-08-31 17:42:06][+] content_type_options_vuln: name: content_type_options_vuln, author: OWASP Nettacker Team, severity: 2, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity']
-[2021-08-31 17:42:06][+] apache_struts_vuln: name: apache_struts_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'low_severity', 'apache_struts']
-[2021-08-31 17:42:06][+] vbulletin_cve_2019_16759_vuln: name: vbulletin_cve_2019_16759_vuln, author: OWASP Nettacker Team, severity: 9, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'critical_severity', 'vbulletin', 'cve']
-[2021-08-31 17:42:06][+] msexchange_cve_2021_26855_vuln: name: msexchange_cve_2021_26855_vuln, author: OWASP Nettacker Team, severity: 9, description: None, reference: None, profiles: ['vuln', 'vulnerability', 'http', 'critical_severity', 'msexchange', 'cve']
-[2021-08-31 17:42:06][+] telnet_brute: name: telnet_brute, author: OWASP Nettacker Team, severity: 3, description: Telnet Bruteforcer, reference: None, profiles: ['brute', 'brute_force', 'telnet']
-[2021-08-31 17:42:06][+] ssh_brute: name: ssh_brute, author: OWASP Nettacker Team, severity: 3, description: SSH Bruteforcer, reference: None, profiles: ['brute', 'brute_force', 'ssh']
-[2021-08-31 17:42:06][+] smtp_brute: name: smtp_brute, author: OWASP Nettacker Team, severity: 3, description: SMTP Bruteforcer, reference: None, profiles: ['brute', 'brute_force', 'smtp']
-[2021-08-31 17:42:06][+] ftps_brute: name: ftps_brute, author: OWASP Nettacker Team, severity: 3, description: FTPS Bruteforcer, reference: None, profiles: ['brute', 'brute_force', 'ftp']
-[2021-08-31 17:42:06][+] smtps_brute: name: smtps_brute, author: OWASP Nettacker Team, severity: 3, description: SMTPS Bruteforcer, reference: None, profiles: ['brute', 'brute_force', 'smtp']
-[2021-08-31 17:42:06][+] ftp_brute: name: ftp_brute, author: OWASP Nettacker Team, severity: 3, description: FTP Bruteforcer, reference: None, profiles: ['brute', 'brute_force', 'ftp']
+[2021-08-31 17:42:06][+] http_options_enabled_vuln: name: http_options_enabled_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity']
+[2021-08-31 17:42:06][+] clickjacking_vuln: name: clickjacking_vuln, author: OWASP Nettacker Team, severity: 5, description: Clickjacking, also known as a "UI redress attack", is when an attacker uses multiple transparent or opaque layers to trick a user into clicking on a button, reference: https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html, profiles: ['vuln', 'http', 'medium_severity']
+[2021-08-31 17:42:06][+] wp_xmlrpc_bruteforce_vuln: name: wp_xmlrpc_bruteforce_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity', 'wordpress']
+[2021-08-31 17:42:06][+] graphql_vuln: name: graphql_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity', 'graphql']
+[2021-08-31 17:42:06][+] content_security_policy_vuln: name: content_security_policy_vuln, author: OWASP Nettacker Team, severity: 3, description: Content-Security-Policy is the name of a HTTP response header that modern browsers use to enhance the security of the document (or web page). The Content-Security-Policy header allows you to restrict how resources such as JavaScript, CSS, or pretty much anything that the browser loads., reference: https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html, profiles: ['vuln', 'http', 'low_severity', 'csp']
+[2021-08-31 17:42:06][+] xdebug_rce_vuln: name: xdebug_rce_vuln, author: OWASP Nettacker Team, severity: 10, description: None, reference: None, profiles: ['vuln', 'http', 'critical_severity']
+[2021-08-31 17:42:06][+] x_powered_by_vuln: name: x_powered_by_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity']
+[2021-08-31 17:42:06][+] wp_xmlrpc_pingback_vuln: name: wp_xmlrpc_pingback_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'wordpress']
+[2021-08-31 17:42:06][+] http_cors_vuln: name: http_cors_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity']
+[2021-08-31 17:42:06][+] f5_cve_2020_5902_vuln: name: f5_cve_2020_5902_vuln, author: OWASP Nettacker Team, severity: 9, description: None, reference: None, profiles: ['vuln', 'http', 'critical_severity', 'cve', 'f5']
+[2021-08-31 17:42:06][+] subdomain_takeover_vuln: name: subdomain_takeover_vuln, author: OWASP Nettacker Team, severity: 5, description: let us assume that example.com is the target and that the team running example.com have a bug bounty programme. While enumerating all of the subdomains belonging to example.com — a process that we will explore later — a hacker stumbles across subdomain.example.com, a subdomain pointing to GitHub pages. We can determine this by reviewing the subdomain's DNS records; in this example, subdomain.example.com has multiple A records pointing to GitHub's dedicated IP addresses for custom pages., reference: https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover, profiles: ['vuln', 'http', 'medium_severity', 'takeover']
+[2021-08-31 17:42:06][+] http_trace_enabled_vuln: name: http_trace_enabled_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity']
+[2021-08-31 17:42:06][+] http_cookie_vuln: name: http_cookie_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity']
+[2021-08-31 17:42:06][+] wp_xmlrpc_dos_vuln: name: wp_xmlrpc_dos_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'wordpress']
+[2021-08-31 17:42:06][+] server_version_vuln: name: server_version_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity']
+[2021-08-31 17:42:06][+] x_xss_protection_vuln: name: x_xss_protection_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity']
+[2021-08-31 17:42:06][+] citrix_cve_2019_19781_vuln: name: citrix_cve_2019_19781_vuln, author: OWASP Nettacker Team, severity: 8, description: None, reference: None, profiles: ['vuln', 'http', 'high_severity', 'cve', 'citrix']
+[2021-08-31 17:42:06][+] content_type_options_vuln: name: content_type_options_vuln, author: OWASP Nettacker Team, severity: 2, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity']
+[2021-08-31 17:42:06][+] apache_struts_vuln: name: apache_struts_vuln, author: OWASP Nettacker Team, severity: 3, description: None, reference: None, profiles: ['vuln', 'http', 'low_severity', 'apache_struts']
+[2021-08-31 17:42:06][+] vbulletin_cve_2019_16759_vuln: name: vbulletin_cve_2019_16759_vuln, author: OWASP Nettacker Team, severity: 9, description: None, reference: None, profiles: ['vuln', 'http', 'critical_severity', 'vbulletin', 'cve']
+[2021-08-31 17:42:06][+] msexchange_cve_2021_26855_vuln: name: msexchange_cve_2021_26855_vuln, author: OWASP Nettacker Team, severity: 9, description: None, reference: None, profiles: ['vuln', 'http', 'critical_severity', 'msexchange', 'cve']
+[2021-08-31 17:42:06][+] telnet_brute: name: telnet_brute, author: OWASP Nettacker Team, severity: 3, description: Telnet Bruteforcer, reference: None, profiles: ['brute', 'telnet']
+[2021-08-31 17:42:06][+] ssh_brute: name: ssh_brute, author: OWASP Nettacker Team, severity: 3, description: SSH Bruteforcer, reference: None, profiles: ['brute', 'ssh']
+[2021-08-31 17:42:06][+] smtp_brute: name: smtp_brute, author: OWASP Nettacker Team, severity: 3, description: SMTP Bruteforcer, reference: None, profiles: ['brute', 'smtp']
+[2021-08-31 17:42:06][+] ftps_brute: name: ftps_brute, author: OWASP Nettacker Team, severity: 3, description: FTPS Bruteforcer, reference: None, profiles: ['brute', 'ftp']
+[2021-08-31 17:42:06][+] smtps_brute: name: smtps_brute, author: OWASP Nettacker Team, severity: 3, description: SMTPS Bruteforcer, reference: None, profiles: ['brute', 'smtp']
+[2021-08-31 17:42:06][+] ftp_brute: name: ftp_brute, author: OWASP Nettacker Team, severity: 3, description: FTP Bruteforcer, reference: None, profiles: ['brute', 'ftp']
 [2021-08-31 17:42:06][+] whatcms_scan: name: dir_scan, author: OWASP Nettacker Team, severity: 3, description: Directory, Backup finder, reference: https://www.zaproxy.org/docs/alerts/10095/, profiles: ['scan', 'http', 'backup', 'low_severity']
-[2021-08-31 17:42:06][+] icmp_scan: name: icmp_scan, author: OWASP Nettacker Team, severity: 0, description: check if host is alive through ICMP, reference: None, profiles: ['scan', 'information_gathering', 'infortmation', 'info', 'low_severity']
-[2021-08-31 17:42:06][+] subdomain_scan: name: subdomain_scan, author: OWASP Nettacker Team, severity: 0, description: Find subdomains using different sources on internet, reference: None, profiles: ['scan', 'information_gathering', 'infortmation', 'info', 'low_severity']
-[2021-08-31 17:42:06][+] port_scan: id: port_scan, author: OWASP Nettacker Team, severity: 0, description: Find open ports and services, reference: None, profiles: ['scan', 'http', 'information_gathering', 'infortmation', 'info', 'low_severity']
+[2021-08-31 17:42:06][+] icmp_scan: name: icmp_scan, author: OWASP Nettacker Team, severity: 0, description: check if host is alive through ICMP, reference: None, profiles: ['scan', 'info', 'low_severity']
+[2021-08-31 17:42:06][+] subdomain_scan: name: subdomain_scan, author: OWASP Nettacker Team, severity: 0, description: Find subdomains using different sources on internet, reference: None, profiles: ['scan', 'info', 'low_severity']
+[2021-08-31 17:42:06][+] port_scan: id: port_scan, author: OWASP Nettacker Team, severity: 0, description: Find open ports and services, reference: None, profiles: ['scan', 'http', 'info', 'low_severity']
 [2021-08-31 17:42:06][+] admin_scan: name: admin_scan, author: OWASP Nettacker Team, severity: 3, description: Admin Directory Finder, reference: None, profiles: ['scan', 'http', 'backup', 'low_severity']
 [2021-08-31 17:42:06][+] dir_scan: name: dir_scan, author: OWASP Nettacker Team, severity: 3, description: Directory, Backup finder, reference: https://www.zaproxy.org/docs/alerts/10095/, profiles: ['scan', 'http', 'backup', 'low_severity']
 [2021-08-31 17:42:06][+] viewdns_reverse_iplookup_scan: name: viewdns_reverse_iplookup_scan, author: OWASP Nettacker Team, severity: 3, description: reverse lookup for target ip, reference: None, profiles: ['scan', 'http', 'backup', 'low_severity', 'reverse_lookup']
 [2021-08-31 17:42:06][+] drupal_version_scan: name: drupal_version_scan, author: OWASP Nettacker Team, severity: 3, description: fetch drupal version from target, reference: None, profiles: ['scan', 'http', 'backup', 'low_severity', 'drupal']
 [2021-08-31 17:42:06][+] joomla_version_scan: name: drupal_version_scan, author: OWASP Nettacker Team, severity: 3, description: fetch drupal version from target, reference: None, profiles: ['scan', 'http', 'backup', 'low_severity', 'drupal']
-[2021-08-31 17:42:06][+] wordpress_version_scan: name: wordpress_version_scan, author: OWASP Nettacker Team, severity: 3, description: Directory, Backup finder, reference: None, profiles: ['scan', 'http', 'backup', 'low_severity', 'wp', 'wordpress']
+[2021-08-31 17:42:06][+] wordpress_version_scan: name: wordpress_version_scan, author: OWASP Nettacker Team, severity: 3, description: Directory, Backup finder, reference: None, profiles: ['scan', 'http', 'backup', 'low_severity', 'wordpress']
 [2021-08-31 17:42:06][+] pma_scan: name: pma_scan, author: OWASP Nettacker Team, severity: 3, description: php my admin finder, reference: None, profiles: ['scan', 'http', 'backup', 'low_severity']
 [2021-08-31 17:42:06][+] all:
 ```
@@ -470,8 +470,6 @@ info:
   reference:
   profiles:
     - scan
-    - information_gathering
-    - infortmation
     - info
     - low_severity
     - asset_discovery(new added profile)

--- a/nettacker/modules/brute/ftp.yaml
+++ b/nettacker/modules/brute/ftp.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - brute
-    - brute_force
     - ftp
 
 payloads:

--- a/nettacker/modules/brute/ftps.yaml
+++ b/nettacker/modules/brute/ftps.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - brute
-    - brute_force
     - ftp
 
 payloads:

--- a/nettacker/modules/brute/pop3.yaml
+++ b/nettacker/modules/brute/pop3.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - brute
-    - brute_force
     - pop3
 
 payloads:

--- a/nettacker/modules/brute/pop3s.yaml
+++ b/nettacker/modules/brute/pop3s.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - brute
-    - brute_force
     - pop3
 
 payloads:

--- a/nettacker/modules/brute/smtp.yaml
+++ b/nettacker/modules/brute/smtp.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - brute
-    - brute_force
     - smtp
 
 payloads:

--- a/nettacker/modules/brute/smtps.yaml
+++ b/nettacker/modules/brute/smtps.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - brute
-    - brute_force
     - smtp
 
 payloads:

--- a/nettacker/modules/brute/ssh.yaml
+++ b/nettacker/modules/brute/ssh.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - brute
-    - brute_force
     - ssh
 
 payloads:

--- a/nettacker/modules/brute/telnet.yaml
+++ b/nettacker/modules/brute/telnet.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - brute
-    - brute_force
     - telnet
 
 payloads:

--- a/nettacker/modules/scan/icmp.yaml
+++ b/nettacker/modules/scan/icmp.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - scan
-    - information_gathering
     - infortmation
     - info
     - low_severity

--- a/nettacker/modules/scan/icmp.yaml
+++ b/nettacker/modules/scan/icmp.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - scan
-    - infortmation
     - info
     - low_severity
 

--- a/nettacker/modules/scan/port.yaml
+++ b/nettacker/modules/scan/port.yaml
@@ -7,7 +7,6 @@ info:
   profiles:
     - scan
     - http
-    - information_gathering
     - infortmation
     - info
     - low_severity

--- a/nettacker/modules/scan/port.yaml
+++ b/nettacker/modules/scan/port.yaml
@@ -7,7 +7,6 @@ info:
   profiles:
     - scan
     - http
-    - infortmation
     - info
     - low_severity
 

--- a/nettacker/modules/scan/subdomain.yaml
+++ b/nettacker/modules/scan/subdomain.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - scan
-    - information_gathering
     - infortmation
     - info
     - low_severity

--- a/nettacker/modules/scan/subdomain.yaml
+++ b/nettacker/modules/scan/subdomain.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - scan
-    - infortmation
     - info
     - low_severity
 

--- a/nettacker/modules/scan/wordpress_version.yaml
+++ b/nettacker/modules/scan/wordpress_version.yaml
@@ -9,7 +9,6 @@ info:
     - http
     - backup
     - low_severity
-    - wp
     - wordpress
 
 payloads:

--- a/nettacker/modules/scan/wp_plugin.yaml
+++ b/nettacker/modules/scan/wp_plugin.yaml
@@ -9,7 +9,6 @@ info:
     - http
     - backup
     - low_severity
-    - wp
     - wordpress
 payloads:
   - library: http

--- a/nettacker/modules/scan/wp_theme.yaml
+++ b/nettacker/modules/scan/wp_theme.yaml
@@ -9,7 +9,6 @@ info:
     - http
     - backup
     - low_severity
-    - wp
     - wordpress
     - wp_theme
 

--- a/nettacker/modules/scan/wp_timethumbs.yaml
+++ b/nettacker/modules/scan/wp_timethumbs.yaml
@@ -9,7 +9,6 @@ info:
     - http
     - backup
     - low_severity
-    - wp
     - wp_timethumbs
     - wordpress
 

--- a/nettacker/modules/vuln/accela_cve_2021_34370.yaml
+++ b/nettacker/modules/vuln/accela_cve_2021_34370.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-34370
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/adobe_coldfusion_cve_2023_26360.yaml
+++ b/nettacker/modules/vuln/adobe_coldfusion_cve_2023_26360.yaml
@@ -9,7 +9,6 @@ info:
     - http://packetstormsecurity.com/files/172079/Adobe-ColdFusion-Unauthenticated-Remote-Code-Execution.html
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve

--- a/nettacker/modules/vuln/apache_cve_2021_41773.yaml
+++ b/nettacker/modules/vuln/apache_cve_2021_41773.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-41773
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2021

--- a/nettacker/modules/vuln/apache_cve_2021_42013.yaml
+++ b/nettacker/modules/vuln/apache_cve_2021_42013.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-42013
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2021

--- a/nettacker/modules/vuln/apache_ofbiz_cve_2024_38856.yaml
+++ b/nettacker/modules/vuln/apache_ofbiz_cve_2024_38856.yaml
@@ -10,7 +10,6 @@ info:
    
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve

--- a/nettacker/modules/vuln/apache_struts.yaml
+++ b/nettacker/modules/vuln/apache_struts.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
     - apache_struts

--- a/nettacker/modules/vuln/aviatrix_cve_2021_40870.yaml
+++ b/nettacker/modules/vuln/aviatrix_cve_2021_40870.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-40870
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2021

--- a/nettacker/modules/vuln/cisco_hyperflex_cve_2021_1497.yaml
+++ b/nettacker/modules/vuln/cisco_hyperflex_cve_2021_1497.yaml
@@ -8,7 +8,6 @@ info:
     - https://packetstormsecurity.com/files/162976/Cisco-HyperFlex-HX-Data-Platform-Command-Execution.html
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve

--- a/nettacker/modules/vuln/citrix_cve_2019_19781.yaml
+++ b/nettacker/modules/vuln/citrix_cve_2019_19781.yaml
@@ -7,7 +7,6 @@ info:
     - https://support.citrix.com/article/CTX267027
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve

--- a/nettacker/modules/vuln/citrix_cve_2023_24488.yaml
+++ b/nettacker/modules/vuln/citrix_cve_2023_24488.yaml
@@ -9,7 +9,6 @@ info:
     - https://blog.assetnote.io/2023/06/29/citrix-xss-advisory/
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve

--- a/nettacker/modules/vuln/citrix_cve_2023_4966.yaml
+++ b/nettacker/modules/vuln/citrix_cve_2023_4966.yaml
@@ -10,7 +10,6 @@ info:
     - https://github.com/advisories/GHSA-2g42-2pwg-93cj
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve

--- a/nettacker/modules/vuln/clickjacking.yaml
+++ b/nettacker/modules/vuln/clickjacking.yaml
@@ -6,7 +6,6 @@ info:
   reference: "https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html"
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
 

--- a/nettacker/modules/vuln/cloudron_cve_2021_40868.yaml
+++ b/nettacker/modules/vuln/cloudron_cve_2021_40868.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-40868
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/confluence_cve_2023_22515.yaml
+++ b/nettacker/modules/vuln/confluence_cve_2023_22515.yaml
@@ -12,7 +12,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-22515
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve

--- a/nettacker/modules/vuln/confluence_cve_2023_22527.yaml
+++ b/nettacker/modules/vuln/confluence_cve_2023_22527.yaml
@@ -9,7 +9,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-22527
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve

--- a/nettacker/modules/vuln/content_security_policy.yaml
+++ b/nettacker/modules/vuln/content_security_policy.yaml
@@ -6,7 +6,6 @@ info:
   reference: "https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html"
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
     - csp

--- a/nettacker/modules/vuln/content_type_options.yaml
+++ b/nettacker/modules/vuln/content_type_options.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
 

--- a/nettacker/modules/vuln/cyberoam_netgenie_cve_2021_38702.yaml
+++ b/nettacker/modules/vuln/cyberoam_netgenie_cve_2021_38702.yaml
@@ -8,7 +8,6 @@ info:
     - vuln
     - http
     - medium_severity
-    - cve_2021_38702
     - cve2021
     - cve
     - cyberoam

--- a/nettacker/modules/vuln/cyberoam_netgenie_cve_2021_38702.yaml
+++ b/nettacker/modules/vuln/cyberoam_netgenie_cve_2021_38702.yaml
@@ -6,7 +6,6 @@ info:
   reference: https://seclists.org/fulldisclosure/2021/Aug/20
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve_2021_38702

--- a/nettacker/modules/vuln/exponent_cms_cve_2021_38751.yaml
+++ b/nettacker/modules/vuln/exponent_cms_cve_2021_38751.yaml
@@ -8,7 +8,6 @@ info:
     - https://github.com/exponentcms/exponent-cms/blob/a9fa9358c5e8dc2ce7ad61d7d5bea38505b8515c/exponent_constants.php#L56-L64
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve

--- a/nettacker/modules/vuln/f5_cve_2020_5902.yaml
+++ b/nettacker/modules/vuln/f5_cve_2020_5902.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve

--- a/nettacker/modules/vuln/forgerock_am_cve_2021_35464.yaml
+++ b/nettacker/modules/vuln/forgerock_am_cve_2021_35464.yaml
@@ -7,7 +7,6 @@ info:
     - https://portswigger.net/research/pre-auth-rce-in-forgerock-openam-cve-2021-35464
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2021

--- a/nettacker/modules/vuln/galera_webtemp_cve_2021_40960.yaml
+++ b/nettacker/modules/vuln/galera_webtemp_cve_2021_40960.yaml
@@ -8,7 +8,6 @@ info:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-40960
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve2021

--- a/nettacker/modules/vuln/grafana_cve_2021_43798.yaml
+++ b/nettacker/modules/vuln/grafana_cve_2021_43798.yaml
@@ -8,7 +8,6 @@ info:
     - https://github.com/jas502n/Grafana-VulnTips
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - grafana

--- a/nettacker/modules/vuln/graphql.yaml
+++ b/nettacker/modules/vuln/graphql.yaml
@@ -6,7 +6,7 @@ info:
   reference:
   profiles:
     - vuln
-    - information_gathering
+    - info
     - http
     - low_severity
     - graphql

--- a/nettacker/modules/vuln/graphql.yaml
+++ b/nettacker/modules/vuln/graphql.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - info
     - http
     - low_severity
     - graphql

--- a/nettacker/modules/vuln/gurock_testrail_cve_2021_40875.yaml
+++ b/nettacker/modules/vuln/gurock_testrail_cve_2021_40875.yaml
@@ -8,7 +8,6 @@ info:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-40875
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/hoteldruid_cve_2021-37833.yaml
+++ b/nettacker/modules/vuln/hoteldruid_cve_2021-37833.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-37833
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/http_cookie.yaml
+++ b/nettacker/modules/vuln/http_cookie.yaml
@@ -8,7 +8,6 @@ info:
     - https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
 

--- a/nettacker/modules/vuln/http_cors.yaml
+++ b/nettacker/modules/vuln/http_cors.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
 

--- a/nettacker/modules/vuln/http_options_enabled.yaml
+++ b/nettacker/modules/vuln/http_options_enabled.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
 

--- a/nettacker/modules/vuln/ivanti_epmm_cve_2023_35082.yaml
+++ b/nettacker/modules/vuln/ivanti_epmm_cve_2023_35082.yaml
@@ -10,7 +10,6 @@ info:
     - https://www.rapid7.com/blog/post/2023/08/02/cve-2023-35082-mobileiron-core-unauthenticated-api-access-vulnerability/
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve

--- a/nettacker/modules/vuln/ivanti_ics_cve_2023_46805.yaml
+++ b/nettacker/modules/vuln/ivanti_ics_cve_2023_46805.yaml
@@ -8,7 +8,6 @@ info:
     - https://labs.watchtowr.com/welcome-to-2024-the-sslvpn-chaos-continues-ivanti-cve-2023-46805-cve-2024-21887
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve

--- a/nettacker/modules/vuln/justwirting_cve_2021_41878.yaml
+++ b/nettacker/modules/vuln/justwirting_cve_2021_41878.yaml
@@ -8,7 +8,6 @@ info:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41878
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/log4j_cve_2021_44228.yaml
+++ b/nettacker/modules/vuln/log4j_cve_2021_44228.yaml
@@ -8,7 +8,6 @@ info:
     - https://github.com/huntresslabs/log4shell-tester
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2021

--- a/nettacker/modules/vuln/maxsite_cms_cve_2021_35265.yaml
+++ b/nettacker/modules/vuln/maxsite_cms_cve_2021_35265.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-35265
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/msexchange_cve_2021_26855.yaml
+++ b/nettacker/modules/vuln/msexchange_cve_2021_26855.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - msexchange

--- a/nettacker/modules/vuln/msexchange_cve_2021_34473.yaml
+++ b/nettacker/modules/vuln/msexchange_cve_2021_34473.yaml
@@ -8,7 +8,6 @@ info:
     - https://blog.orange.tw/2021/08/proxylogon-a-new-attack-surface-on-ms-exchange-part-1.html
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - msexchange

--- a/nettacker/modules/vuln/novnc_cve_2021_3654.yaml
+++ b/nettacker/modules/vuln/novnc_cve_2021_3654.yaml
@@ -8,7 +8,6 @@ info:
     - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3654
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
     - cve2021

--- a/nettacker/modules/vuln/omigod_cve_2021_38647.yaml
+++ b/nettacker/modules/vuln/omigod_cve_2021_38647.yaml
@@ -8,7 +8,6 @@ info:
     - https://github.com/microsoft/omi
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2021

--- a/nettacker/modules/vuln/paloalto_panos_cve_2025_0108.yaml
+++ b/nettacker/modules/vuln/paloalto_panos_cve_2025_0108.yaml
@@ -10,7 +10,6 @@ info:
     - https://thehackernews.com/2025/02/cisa-adds-palo-alto-networks-and.html
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve

--- a/nettacker/modules/vuln/payara_cve_2021_41381.yaml
+++ b/nettacker/modules/vuln/payara_cve_2021_41381.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-41381
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/phpinfo_cve_2021_37704.yaml
+++ b/nettacker/modules/vuln/phpinfo_cve_2021_37704.yaml
@@ -8,7 +8,6 @@ info:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37704
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/placeos_cve_2021_41826.yaml
+++ b/nettacker/modules/vuln/placeos_cve_2021_41826.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-41826
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
     - cve2021

--- a/nettacker/modules/vuln/prestashop_cve_2021_37538.yaml
+++ b/nettacker/modules/vuln/prestashop_cve_2021_37538.yaml
@@ -8,7 +8,6 @@ info:
     - https://blog.sorcery.ie/posts/smartblog_sqli/
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2021

--- a/nettacker/modules/vuln/puneethreddyhc_sqli_cve_2021_41648.yaml
+++ b/nettacker/modules/vuln/puneethreddyhc_sqli_cve_2021_41648.yaml
@@ -11,7 +11,6 @@ info:
     - high_severity
     - cve2021
     - cve
-    - puneethreddyhc
     - sqli
 
 payloads:

--- a/nettacker/modules/vuln/puneethreddyhc_sqli_cve_2021_41648.yaml
+++ b/nettacker/modules/vuln/puneethreddyhc_sqli_cve_2021_41648.yaml
@@ -7,7 +7,6 @@ info:
     - https://github.com/MobiusBinary/CVE-2021-41648
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve2021

--- a/nettacker/modules/vuln/puneethreddyhc_sqli_cve_2021_41649.yaml
+++ b/nettacker/modules/vuln/puneethreddyhc_sqli_cve_2021_41649.yaml
@@ -11,7 +11,6 @@ info:
     - high_severity
     - cve2021
     - cve
-    - puneethreddyhc
     - sqli
 
 payloads:

--- a/nettacker/modules/vuln/puneethreddyhc_sqli_cve_2021_41649.yaml
+++ b/nettacker/modules/vuln/puneethreddyhc_sqli_cve_2021_41649.yaml
@@ -7,7 +7,6 @@ info:
     - https://github.com/MobiusBinary/CVE-2021-41649
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve2021

--- a/nettacker/modules/vuln/qsan_storage_xss_cve_2021_37216.yaml
+++ b/nettacker/modules/vuln/qsan_storage_xss_cve_2021_37216.yaml
@@ -7,7 +7,6 @@ info:
     - https://www.twcert.org.tw/tw/cp-132-4962-44cd2-1.html
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/server_version.yaml
+++ b/nettacker/modules/vuln/server_version.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
 

--- a/nettacker/modules/vuln/sonicwall_sslvpn_cve_2024_53704.yaml
+++ b/nettacker/modules/vuln/sonicwall_sslvpn_cve_2024_53704.yaml
@@ -9,7 +9,6 @@ info:
     - https://www.cisa.gov/news-events/alerts/2025/02/18/cisa-adds-two-known-exploited-vulnerabilities-catalog
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve

--- a/nettacker/modules/vuln/strict_transport_security.yaml
+++ b/nettacker/modules/vuln/strict_transport_security.yaml
@@ -8,7 +8,6 @@ info:
     - https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
 

--- a/nettacker/modules/vuln/subdomain_takeover.yaml
+++ b/nettacker/modules/vuln/subdomain_takeover.yaml
@@ -6,7 +6,6 @@ info:
   reference: "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/10-Test_for_Subdomain_Takeover"
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - takeover

--- a/nettacker/modules/vuln/teamcity_cve_2024_27198.yaml
+++ b/nettacker/modules/vuln/teamcity_cve_2024_27198.yaml
@@ -10,7 +10,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-27198
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve

--- a/nettacker/modules/vuln/tieline_cve_2021_35336.yaml
+++ b/nettacker/modules/vuln/tieline_cve_2021_35336.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-35336
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2021

--- a/nettacker/modules/vuln/tjws_cve_2021_37573.yaml
+++ b/nettacker/modules/vuln/tjws_cve_2021_37573.yaml
@@ -7,7 +7,6 @@ info:
     - https://seclists.org/fulldisclosure/2021/Aug/13
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/vbulletin_cve_2019_16759.yaml
+++ b/nettacker/modules/vuln/vbulletin_cve_2019_16759.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - vbulletin

--- a/nettacker/modules/vuln/wp_plugin_cve_2021_38314.yaml
+++ b/nettacker/modules/vuln/wp_plugin_cve_2021_38314.yaml
@@ -8,7 +8,6 @@ info:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-38314
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve2021

--- a/nettacker/modules/vuln/wp_plugin_cve_2021_39316.yaml
+++ b/nettacker/modules/vuln/wp_plugin_cve_2021_39316.yaml
@@ -8,7 +8,6 @@ info:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-39316
   profiles:
     - vuln
-    - vulnerability
     - http
     - high_severity
     - cve2021

--- a/nettacker/modules/vuln/wp_plugin_cve_2021_39320.yaml
+++ b/nettacker/modules/vuln/wp_plugin_cve_2021_39320.yaml
@@ -8,7 +8,6 @@ info:
     - https://nvd.nist.gov/vuln/detail/CVE-2021-39320
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - cve2021

--- a/nettacker/modules/vuln/wp_plugin_cve_2023_47668.yaml
+++ b/nettacker/modules/vuln/wp_plugin_cve_2023_47668.yaml
@@ -12,7 +12,6 @@ info:
     - http
     - medium_severity
     - wordpress
-    - wp
 
 payloads:
   - library: http

--- a/nettacker/modules/vuln/wp_plugin_cve_2023_47668.yaml
+++ b/nettacker/modules/vuln/wp_plugin_cve_2023_47668.yaml
@@ -9,7 +9,6 @@ info:
     
   profiles:
     - vuln
-    - vulnerability
     - http
     - medium_severity
     - wordpress

--- a/nettacker/modules/vuln/wp_plugin_cve_2023_6875.yaml
+++ b/nettacker/modules/vuln/wp_plugin_cve_2023_6875.yaml
@@ -9,7 +9,6 @@ info:
     - https://www.cve.org/CVERecord?id=CVE-2023-6875
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2023

--- a/nettacker/modules/vuln/wp_xmlrpc_bruteforce.yaml
+++ b/nettacker/modules/vuln/wp_xmlrpc_bruteforce.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
     - wordpress

--- a/nettacker/modules/vuln/wp_xmlrpc_bruteforce.yaml
+++ b/nettacker/modules/vuln/wp_xmlrpc_bruteforce.yaml
@@ -9,7 +9,6 @@ info:
     - http
     - low_severity
     - wordpress
-    - wp
 
 payloads:
   - library: http

--- a/nettacker/modules/vuln/wp_xmlrpc_dos.yaml
+++ b/nettacker/modules/vuln/wp_xmlrpc_dos.yaml
@@ -8,7 +8,6 @@ info:
     - vuln
     - http
     - wordpress
-    - wp
 
 payloads:
   - library: http

--- a/nettacker/modules/vuln/wp_xmlrpc_dos.yaml
+++ b/nettacker/modules/vuln/wp_xmlrpc_dos.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - wordpress
     - wp

--- a/nettacker/modules/vuln/wp_xmlrpc_pingback.yaml
+++ b/nettacker/modules/vuln/wp_xmlrpc_pingback.yaml
@@ -8,7 +8,6 @@ info:
     - vuln
     - http
     - wordpress
-    - wp
 
 payloads:
   - library: http

--- a/nettacker/modules/vuln/wp_xmlrpc_pingback.yaml
+++ b/nettacker/modules/vuln/wp_xmlrpc_pingback.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - wordpress
     - wp

--- a/nettacker/modules/vuln/x_powered_by.yaml
+++ b/nettacker/modules/vuln/x_powered_by.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
 

--- a/nettacker/modules/vuln/x_xss_protection.yaml
+++ b/nettacker/modules/vuln/x_xss_protection.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - low_severity
 

--- a/nettacker/modules/vuln/xdebug_rce.yaml
+++ b/nettacker/modules/vuln/xdebug_rce.yaml
@@ -6,7 +6,6 @@ info:
   reference:
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - rce

--- a/nettacker/modules/vuln/zoho_cve_2021_40539.yaml
+++ b/nettacker/modules/vuln/zoho_cve_2021_40539.yaml
@@ -8,7 +8,6 @@ info:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-40539
   profiles:
     - vuln
-    - vulnerability
     - http
     - critical_severity
     - cve2021


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

Cleaning the profiles list, as mentioned in #1038. The following changes were made

- [x] removed `vulnerability` from all of them because it was a subset of `vuln` and vuln is easier to type
- [x] remove `brute-force` as its the same as `brute` and brute is better.
- [x] check for cve_2021_something and add that to cve2021 and cve only.
- [x] removed the `puneethreddyrc` profile
- [x] `info` and `information-gathering`, keeping it consistent and non-redundant.
- [x] `wp` and `wordpress`, keeping it consistent and non-redudant.
- [x] remove `infortmation`
- [x] Make relevant changes to the doc. 

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
