### PR TITLE
added clean exit for missing wordlists

### DIFF
--- a/nettacker/core/arg_parser.py
+++ b/nettacker/core/arg_parser.py
@@ -676,6 +676,12 @@ class ArgParser(ArgumentParser):
                 options.passwords = list(set(open(options.passwords_list).read().split("\n")))
             except Exception:
                 die_failure(_("error_passwords").format(options.passwords_list))
+        # Check custom wordlist
+        if options.read_from_file:
+            try:
+                open(options.read_from_file).read().split("\n")
+            except Exception:
+                die_failure(_("error_wordlist").format(options.read_from_file))
         # Check output file
         try:
             temp_file = open(options.report_path_filename, "w")

--- a/nettacker/locale/en.yaml
+++ b/nettacker/locale/en.yaml
@@ -36,6 +36,7 @@ error_target: Cannot specify the target(s)
 error_target_file: "Cannot specify the target(s), unable to open file: {0}"
 error_username: "Cannot specify the username(s), unable to open file: {0}"
 error_passwords: "Cannot specify the password(s), unable to open file: {0}"
+error_wordlist: "Cannot specify the word(s), unable to open file {0}"
 exclude_scan_method: choose scan method to exclude {0}
 file_write_error: file "{0}" is not writable!
 library_not_supported: library [{0}] is not support!


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

In case of incorrect wordlist specified through CLI implemented in PR #1026, Nettacker wasn't exiting cleanly. Hence, added the clean exit part. 

![image](https://github.com/user-attachments/assets/6f159956-63ba-42bc-a7c8-842ab36a7722)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
