### PR TITLE
Implementing logging response_dependent conditions in socket.py

### DIFF
--- a/nettacker/core/lib/socket.py
+++ b/nettacker/core/lib/socket.py
@@ -11,7 +11,7 @@ import struct
 import time
 
 from nettacker.core.lib.base import BaseEngine, BaseLibrary
-from nettacker.core.utils.common import reverse_and_regex_condition
+from nettacker.core.utils.common import reverse_and_regex_condition, replace_dependent_response
 
 log = logging.getLogger(__name__)
 
@@ -226,7 +226,7 @@ class SocketEngine(BaseEngine):
     library = SocketLibrary
 
     def response_conditions_matched(self, sub_step, response):
-        conditions = sub_step["response"]["conditions"]
+        conditions = sub_step["response"]["conditions"]["service"]
         condition_type = sub_step["response"]["condition_type"]
         condition_results = {}
         if sub_step["method"] == "tcp_connect_only":
@@ -242,15 +242,35 @@ class SocketEngine(BaseEngine):
                     )
                     reverse = conditions[condition]["reverse"]
                     condition_results[condition] = reverse_and_regex_condition(regex, reverse)
+                    
+                    if condition_results[condition]:
+                        default_service = response["service"]
+                        ssl_flag = response["ssl_flag"]
+                        matched_regex = condition_results[condition]
+
+                        log_response = {
+                        "running_service": condition,
+                        "matched_regex": matched_regex,
+                        "default_service": default_service,
+                        "ssl_flag": ssl_flag
+                        }
+                        condition_results["service"] = [str(log_response)]
                 for condition in copy.deepcopy(condition_results):
                     if not condition_results[condition]:
                         del condition_results[condition]
+
                 if "open_port" in condition_results and len(condition_results) > 1:
                     del condition_results["open_port"]
                     del conditions["open_port"]
-                if condition_type == "and":
+                if condition_type.lower() == "and":
                     return condition_results if len(condition_results) == len(conditions) else []
-                if condition_type == "or":
+                if condition_type.lower() == "or":
+                    if sub_step["response"].get("log", False):
+                        condition_results["log"] = sub_step["response"]["log"]
+                        if "response_dependent" in condition_results["log"]:
+                            condition_results["log"] = replace_dependent_response(
+                                condition_results["log"], condition_results
+                            )
                     return condition_results if condition_results else []
                 return []
         if sub_step["method"] == "socket_icmp":

--- a/nettacker/core/lib/socket.py
+++ b/nettacker/core/lib/socket.py
@@ -226,7 +226,9 @@ class SocketEngine(BaseEngine):
     library = SocketLibrary
 
     def response_conditions_matched(self, sub_step, response):
-        conditions = sub_step["response"]["conditions"]["service"]
+        conditions = sub_step["response"]["conditions"].get(
+            "service", sub_step["response"]["conditions"]
+        )
         condition_type = sub_step["response"]["condition_type"]
         condition_results = {}
         if sub_step["method"] == "tcp_connect_only":
@@ -242,17 +244,17 @@ class SocketEngine(BaseEngine):
                     )
                     reverse = conditions[condition]["reverse"]
                     condition_results[condition] = reverse_and_regex_condition(regex, reverse)
-                    
+
                     if condition_results[condition]:
                         default_service = response["service"]
                         ssl_flag = response["ssl_flag"]
                         matched_regex = condition_results[condition]
 
                         log_response = {
-                        "running_service": condition,
-                        "matched_regex": matched_regex,
-                        "default_service": default_service,
-                        "ssl_flag": ssl_flag
+                            "running_service": condition,
+                            "matched_regex": matched_regex,
+                            "default_service": default_service,
+                            "ssl_flag": ssl_flag,
                         }
                         condition_results["service"] = [str(log_response)]
                 for condition in copy.deepcopy(condition_results):

--- a/nettacker/core/module.py
+++ b/nettacker/core/module.py
@@ -59,7 +59,11 @@ class Module:
 
         contents = TemplateLoader("port_scan", {"target": ""}).load()
         self.service_discovery_signatures = list(
-            set(contents["payloads"][0]["steps"][0]["response"]["conditions"].keys())
+            set(
+                contents["payloads"][0]["steps"][0]["response"]["conditions"]
+                .get("service", set(contents["payloads"][0]["steps"][0]["response"]["conditions"]))
+                .keys()
+            )
         )
 
         self.libraries = [

--- a/nettacker/modules/scan/port.yaml
+++ b/nettacker/modules/scan/port.yaml
@@ -1026,70 +1026,72 @@ payloads:
           - 65389
         response:
           condition_type: or
+          log: "response_dependent['service']"
           conditions:
-            open_port:
-              regex: \d{{1,5}}
-              reverse: false
+            service:
+              open_port:
+                regex: \d{{1,5}}
+                reverse: false
 
-            ftp: &ftp
-              regex: "220-You are user number|530 USER and PASS required|Invalid command: try being more creative|220 \\S+ FTP (Service|service|Server|server)|220 FTP Server ready|Directory status|Service closing control connection|Requested file action|Connection closed; transfer aborted|Directory not empty"
-              reverse: false
-            ftps: *ftp
+              ftp: &ftp
+                regex: "220-You are user number|530 USER and PASS required|Invalid command: try being more creative|220 \\S+ FTP (Service|service|Server|server)|220 FTP Server ready|Directory status|Service closing control connection|Requested file action|Connection closed; transfer aborted|Directory not empty"
+                reverse: false
+              ftps: *ftp
 
-            http:
-              regex: "HTTPStatus.BAD_REQUEST|HTTP\\/[\\d.]+\\s+[\\d]+|Server: |Content-Length: \\d+|Content-Type: |Access-Control-Request-Headers: |Forwarded: |Proxy-Authorization: |User-Agent: |X-Forwarded-Host: |Content-MD5: |Access-Control-Request-Method: |Accept-Language: "
-              reverse: false
+              http:
+                regex: "HTTPStatus.BAD_REQUEST|HTTP\\/[\\d.]+\\s+[\\d]+|Server: |Content-Length: \\d+|Content-Type: |Access-Control-Request-Headers: |Forwarded: |Proxy-Authorization: |User-Agent: |X-Forwarded-Host: |Content-MD5: |Access-Control-Request-Method: |Accept-Language: "
+                reverse: false
 
-            imap:
-              regex: "Internet Mail Server|IMAP4 service|BYE Hi This is the IMAP SSL Redirect|LITERAL\\+ SASL\\-IR LOGIN\\-REFERRALS ID ENABLE IDLE AUTH\\=PLAIN AUTH\\=LOGIN AUTH\\=DIGEST\\-MD5 AUTH\\=CRAM-MD5|CAPABILITY completed|OK IMAPrev1|LITERAL\\+ SASL\\-IR LOGIN\\-REFERRALS ID ENABLE IDLE NAMESPACE AUTH\\=PLAIN AUTH\\=LOGIN|BAD Error in IMAP command received by server|IMAP4rev1 SASL-IR|OK \\[CAPABILITY IMAP4rev1"
-              reverse: false
+              imap:
+                regex: "Internet Mail Server|IMAP4 service|BYE Hi This is the IMAP SSL Redirect|LITERAL\\+ SASL\\-IR LOGIN\\-REFERRALS ID ENABLE IDLE AUTH\\=PLAIN AUTH\\=LOGIN AUTH\\=DIGEST\\-MD5 AUTH\\=CRAM-MD5|CAPABILITY completed|OK IMAPrev1|LITERAL\\+ SASL\\-IR LOGIN\\-REFERRALS ID ENABLE IDLE NAMESPACE AUTH\\=PLAIN AUTH\\=LOGIN|BAD Error in IMAP command received by server|IMAP4rev1 SASL-IR|OK \\[CAPABILITY IMAP4rev1"
+                reverse: false
 
-            mariadb:
-              regex: "is not allowed to connect to this MariaDB server"
-              reverse: false
+              mariadb:
+                regex: "is not allowed to connect to this MariaDB server"
+                reverse: false
 
-            mysql:
-              regex: "is not allowed to connect to this MySQL server"
-              reverse: false
+              mysql:
+                regex: "is not allowed to connect to this MySQL server"
+                reverse: false
 
-            nntp:
-              regex: "NetWare\\-News\\-Server|NetWare nntpd|nntp|Leafnode nntpd|InterNetNews NNRP server INN"
-              reverse: false
+              nntp:
+                regex: "NetWare\\-News\\-Server|NetWare nntpd|nntp|Leafnode nntpd|InterNetNews NNRP server INN"
+                reverse: false
 
-            pop3: &pop3
-              regex: "POP3|POP3 gateway ready|POP3 Server|Welcome to mpopd|OK Hello there"
-              reverse: false
-            pop3s: *pop3
+              pop3: &pop3
+                regex: "POP3|POP3 gateway ready|POP3 Server|Welcome to mpopd|OK Hello there"
+                reverse: false
+              pop3s: *pop3
 
-            portmap:
-              regex: "Program	Version	Protocol	Port|portmapper|nfs	2|nlockmgr	1"
-              reverse: false
+              portmap:
+                regex: "Program	Version	Protocol	Port|portmapper|nfs	2|nlockmgr	1"
+                reverse: false
 
-            postgressql:
-              regex: "FATAL 1\\:  invalid length of startup packet|received invalid response to SSL negotiation\\:|unsupported frontend protocol|fe\\_sendauth\\: no password supplied|no pg\\_hba\\.conf entry for host"
-              reverse: false
+              postgressql:
+                regex: "FATAL 1\\:  invalid length of startup packet|received invalid response to SSL negotiation\\:|unsupported frontend protocol|fe\\_sendauth\\: no password supplied|no pg\\_hba\\.conf entry for host"
+                reverse: false
 
-            pptp:
-              regex: "Hostname: pptp server|Vendor: Fortinet pptp"
-              reverse: false
+              pptp:
+                regex: "Hostname: pptp server|Vendor: Fortinet pptp"
+                reverse: false
 
-            smtp: &smtp
-              regex: "Fidelix Fx2020|ESMTP|Server ready|SMTP synchronization error|220-Greetings|ESMTP Arnet Email Security|SMTP 2.0"
-              reverse: false
-            smtps: *smtp
+              smtp: &smtp
+                regex: "Fidelix Fx2020|ESMTP|Server ready|SMTP synchronization error|220-Greetings|ESMTP Arnet Email Security|SMTP 2.0"
+                reverse: false
+              smtps: *smtp
 
-            rsync:
-              regex: "@RSYNCD\\:"
-              reverse: false
+              rsync:
+                regex: "@RSYNCD\\:"
+                reverse: false
 
-            ssh:
-              regex: "openssh|\\-OpenSSH\\_|\\r?\\n?Protocol mism|\\_sshlib|\\x00\\x1aversion info line too long|SSH Windows NT Server|WinNT sshd|sshd| SSH Secure Shell|WinSSHD|SSH-[\\d.]+-[A-Za-z0-9_\\-]+|SSH-[\\d.]+\\r?\\n?"
-              reverse: false
+              ssh:
+                regex: "openssh|\\-OpenSSH\\_|\\r?\\n?Protocol mism|\\_sshlib|\\x00\\x1aversion info line too long|SSH Windows NT Server|WinNT sshd|sshd| SSH Secure Shell|WinSSHD|SSH-[\\d.]+-[A-Za-z0-9_\\-]+|SSH-[\\d.]+\\r?\\n?"
+                reverse: false
 
-            telnet:
-              regex: "Check Point FireWall-1 authenticated Telnet server running on|Raptor Firewall Secure Gateway|No more connections are allowed to telnet server|Closing Telnet connection due to host problems|NetportExpress|WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING|Login authentication|recommended to use Stelnet|is not a secure protocol|Welcome to Microsoft Telnet Servic|no decompiling or reverse-engineering shall be allowed"
-              reverse: false
+              telnet:
+                regex: "Check Point FireWall-1 authenticated Telnet server running on|Raptor Firewall Secure Gateway|No more connections are allowed to telnet server|Closing Telnet connection due to host problems|NetportExpress|WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING|Login authentication|recommended to use Stelnet|is not a secure protocol|Welcome to Microsoft Telnet Servic|no decompiling or reverse-engineering shall be allowed"
+                reverse: false
 
-            amqp:
-              regex: "AMQP"
-              reverse: false
+              amqp:
+                regex: "AMQP"
+                reverse: false

--- a/tests/core/lib/test_socket.py
+++ b/tests/core/lib/test_socket.py
@@ -9,6 +9,7 @@ class Responses:
 
     tcp_connect_send_and_receive = {
         "response": 'HTTP/1.1 400 Bad Request\r\nServer: Apache/2.4.62 (Debian)\r\nContent-Length: 302\r\nConnection: close\r\nContent-Type: text/html; charset=iso-8859-1\r\n\r\n<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">\n<html><head>\n<title>400 Bad Request</title>\n</head><body>\n<h1>Bad Request</h1>\n<p>Your browser sent a request that this server could not understand.<br />\n</p>\n<hr>\n<address>Apache/2.4.62 (Debian)</address>\n</body></html>\n',
+        "service": "http",
         "peer_name": (
             "127.0.0.1",
             80,
@@ -31,69 +32,75 @@ class Substeps:
         "method": "tcp_connect_send_and_receive",
         "response": {
             "condition_type": "or",
+            "log": "response_dependent['service']",
             "conditions": {
-                "open_port": {"regex": "", "reverse": False},
-                "ftp": {
-                    "regex": "220-You are user number|530 USER and PASS required|Invalid command: try being more creative|220 \\S+ FTP (Service|service|Server|server)|220 FTP Server ready|Directory status|Service closing control connection|Requested file action|Connection closed; transfer aborted|Directory not empty",
-                    "reverse": False,
-                },
-                "ftps": {
-                    "regex": "220-You are user number|530 USER and PASS required|Invalid command: try being more creative|220 \\S+ FTP (Service|service|Server|server)|220 FTP Server ready|Directory status|Service closing control connection|Requested file action|Connection closed; transfer aborted|Directory not empty",
-                    "reverse": False,
-                },
-                "http": {
-                    "regex": "HTTPStatus.BAD_REQUEST|HTTP\\/[\\d.]+\\s+[\\d]+|Server: |Content-Length: \\d+|Content-Type: |Access-Control-Request-Headers: |Forwarded: |Proxy-Authorization: |User-Agent: |X-Forwarded-Host: |Content-MD5: |Access-Control-Request-Method: |Accept-Language: ",
-                    "reverse": False,
-                },
-                "imap": {
-                    "regex": "Internet Mail Server|IMAP4 service|BYE Hi This is the IMAP SSL Redirect|LITERAL\\+ SASL\\-IR LOGIN\\-REFERRALS ID ENABLE IDLE AUTH\\=PLAIN AUTH\\=LOGIN AUTH\\=DIGEST\\-MD5 AUTH\\=CRAM-MD5|CAPABILITY completed|OK IMAPrev1|LITERAL\\+ SASL\\-IR LOGIN\\-REFERRALS ID ENABLE IDLE NAMESPACE AUTH\\=PLAIN AUTH\\=LOGIN|BAD Error in IMAP command received by server|IMAP4rev1 SASL-IR|OK \\[CAPABILITY IMAP4rev1",
-                    "reverse": False,
-                },
-                "mariadb": {
-                    "regex": "is not allowed to connect to this MariaDB server",
-                    "reverse": False,
-                },
-                "mysql": {
-                    "regex": "is not allowed to connect to this MySQL server",
-                    "reverse": False,
-                },
-                "nntp": {
-                    "regex": "NetWare\\-News\\-Server|NetWare nntpd|nntp|Leafnode nntpd|InterNetNews NNRP server INN",
-                    "reverse": False,
-                },
-                "pop3": {
-                    "regex": "POP3|POP3 gateway ready|POP3 Server|Welcome to mpopd|OK Hello there",
-                    "reverse": False,
-                },
-                "pop3s": {
-                    "regex": "POP3|POP3 gateway ready|POP3 Server|Welcome to mpopd|OK Hello there",
-                    "reverse": False,
-                },
-                "portmap": {
-                    "regex": "Program\tVersion\tProtocol\tPort|portmapper|nfs\t2|nlockmgr\t1",
-                    "reverse": False,
-                },
-                "postgressql": {
-                    "regex": "FATAL 1\\:  invalid length of startup packet|received invalid response to SSL negotiation\\:|unsupported frontend protocol|fe\\_sendauth\\: no password supplied|no pg\\_hba\\.conf entry for host",
-                    "reverse": False,
-                },
-                "pptp": {"regex": "Hostname: pptp server|Vendor: Fortinet pptp", "reverse": False},
-                "smtp": {
-                    "regex": "Fidelix Fx2020|ESMTP|Server ready|SMTP synchronization error|220-Greetings|ESMTP Arnet Email Security|SMTP 2.0",
-                    "reverse": False,
-                },
-                "smtps": {
-                    "regex": "Fidelix Fx2020|ESMTP|Server ready|SMTP synchronization error|220-Greetings|ESMTP Arnet Email Security|SMTP 2.0",
-                    "reverse": False,
-                },
-                "rsync": {"regex": "@RSYNCD\\:", "reverse": False},
-                "ssh": {
-                    "regex": "openssh|\\-OpenSSH\\_|\\r\\nProtocol mism|\\_sshlib|\\x00\\x1aversion info line too long|SSH Windows NT Server|WinNT sshd|sshd| SSH Secure Shell|WinSSHD",
-                    "reverse": False,
-                },
-                "telnet": {
-                    "regex": "Check Point FireWall-1 authenticated Telnet server running on|Raptor Firewall Secure Gateway|No more connections are allowed to telnet server|Closing Telnet connection due to host problems|NetportExpress|WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING|Login authentication|recommended to use Stelnet|is not a secure protocol|Welcome to Microsoft Telnet Servic|no decompiling or reverse-engineering shall be allowed",
-                    "reverse": False,
+                "service": {
+                    "open_port": {"regex": "", "reverse": False},
+                    "ftp": {
+                        "regex": "220-You are user number|530 USER and PASS required|Invalid command: try being more creative|220 \\S+ FTP (Service|service|Server|server)|220 FTP Server ready|Directory status|Service closing control connection|Requested file action|Connection closed; transfer aborted|Directory not empty",
+                        "reverse": False,
+                    },
+                    "ftps": {
+                        "regex": "220-You are user number|530 USER and PASS required|Invalid command: try being more creative|220 \\S+ FTP (Service|service|Server|server)|220 FTP Server ready|Directory status|Service closing control connection|Requested file action|Connection closed; transfer aborted|Directory not empty",
+                        "reverse": False,
+                    },
+                    "http": {
+                        "regex": "HTTPStatus.BAD_REQUEST|HTTP\\/[\\d.]+\\s+[\\d]+|Server: |Content-Length: \\d+|Content-Type: |Access-Control-Request-Headers: |Forwarded: |Proxy-Authorization: |User-Agent: |X-Forwarded-Host: |Content-MD5: |Access-Control-Request-Method: |Accept-Language: ",
+                        "reverse": False,
+                    },
+                    "imap": {
+                        "regex": "Internet Mail Server|IMAP4 service|BYE Hi This is the IMAP SSL Redirect|LITERAL\\+ SASL\\-IR LOGIN\\-REFERRALS ID ENABLE IDLE AUTH\\=PLAIN AUTH\\=LOGIN AUTH\\=DIGEST\\-MD5 AUTH\\=CRAM-MD5|CAPABILITY completed|OK IMAPrev1|LITERAL\\+ SASL\\-IR LOGIN\\-REFERRALS ID ENABLE IDLE NAMESPACE AUTH\\=PLAIN AUTH\\=LOGIN|BAD Error in IMAP command received by server|IMAP4rev1 SASL-IR|OK \\[CAPABILITY IMAP4rev1",
+                        "reverse": False,
+                    },
+                    "mariadb": {
+                        "regex": "is not allowed to connect to this MariaDB server",
+                        "reverse": False,
+                    },
+                    "mysql": {
+                        "regex": "is not allowed to connect to this MySQL server",
+                        "reverse": False,
+                    },
+                    "nntp": {
+                        "regex": "NetWare\\-News\\-Server|NetWare nntpd|nntp|Leafnode nntpd|InterNetNews NNRP server INN",
+                        "reverse": False,
+                    },
+                    "pop3": {
+                        "regex": "POP3|POP3 gateway ready|POP3 Server|Welcome to mpopd|OK Hello there",
+                        "reverse": False,
+                    },
+                    "pop3s": {
+                        "regex": "POP3|POP3 gateway ready|POP3 Server|Welcome to mpopd|OK Hello there",
+                        "reverse": False,
+                    },
+                    "portmap": {
+                        "regex": "Program\tVersion\tProtocol\tPort|portmapper|nfs\t2|nlockmgr\t1",
+                        "reverse": False,
+                    },
+                    "postgressql": {
+                        "regex": "FATAL 1\\:  invalid length of startup packet|received invalid response to SSL negotiation\\:|unsupported frontend protocol|fe\\_sendauth\\: no password supplied|no pg\\_hba\\.conf entry for host",
+                        "reverse": False,
+                    },
+                    "pptp": {
+                        "regex": "Hostname: pptp server|Vendor: Fortinet pptp",
+                        "reverse": False,
+                    },
+                    "smtp": {
+                        "regex": "Fidelix Fx2020|ESMTP|Server ready|SMTP synchronization error|220-Greetings|ESMTP Arnet Email Security|SMTP 2.0",
+                        "reverse": False,
+                    },
+                    "smtps": {
+                        "regex": "Fidelix Fx2020|ESMTP|Server ready|SMTP synchronization error|220-Greetings|ESMTP Arnet Email Security|SMTP 2.0",
+                        "reverse": False,
+                    },
+                    "rsync": {"regex": "@RSYNCD\\:", "reverse": False},
+                    "ssh": {
+                        "regex": "openssh|\\-OpenSSH\\_|\\r\\nProtocol mism|\\_sshlib|\\x00\\x1aversion info line too long|SSH Windows NT Server|WinNT sshd|sshd| SSH Secure Shell|WinSSHD",
+                        "reverse": False,
+                    },
+                    "telnet": {
+                        "regex": "Check Point FireWall-1 authenticated Telnet server running on|Raptor Firewall Secure Gateway|No more connections are allowed to telnet server|Closing Telnet connection due to host problems|NetportExpress|WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING|Login authentication|recommended to use Stelnet|is not a secure protocol|Welcome to Microsoft Telnet Servic|no decompiling or reverse-engineering shall be allowed",
+                        "reverse": False,
+                    },
                 },
             },
         },
@@ -150,7 +157,15 @@ class TestSocketMethod(TestCase):
                 )
             ),
             sorted(
-                {"http": ["Content-Type: ", "Content-Length: 302", "HTTP/1.1 400", "Server: "]}
+                {
+                    "http": ["Content-Type: ", "Content-Length: 302", "HTTP/1.1 400", "Server: "],
+                    "log": [
+                        "{'running_service': 'http', 'matched_regex': ['Server: ', 'HTTP/1.1 400', 'Content-Length: 302', 'Content-Type: '], 'default_service': 'http', 'ssl_flag': True}"
+                    ],
+                    "service": [
+                        "{'running_service': 'http', 'matched_regex': ['Server: ', 'HTTP/1.1 400', 'Content-Length: 302', 'Content-Type: '], 'default_service': 'http', 'ssl_flag': True}"
+                    ],
+                }
             ),
         )
 


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->
improvement over #1052. The following changes were made:
- Added response_dependent logging to socket.py
- Updated tests to support the new structure of port.yaml
- Updated module.py to support the new structure for brute attacks 

![image](https://github.com/user-attachments/assets/75256cd8-22c3-48e9-bede-407608ff6fdf)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
