### PR TITLE
Handle socket.gaierror when retrieving server certificate

### DIFF
--- a/nettacker/core/lib/ssl.py
+++ b/nettacker/core/lib/ssl.py
@@ -187,6 +187,8 @@ class SslLibrary(BaseLibrary):
                 cert = ssl.get_server_certificate((host, port))
             except ssl.SSLError:
                 cert = None
+            except socket.gaierror:
+                cert = None
             cert_info = get_cert_info(cert) if cert else None
             ssl_ver, weak_version = is_weak_ssl_version(host, port, timeout)
             cipher_suite, weak_cipher_suite = is_weak_cipher_suite(host, port, timeout)


### PR DESCRIPTION
## Proposed change

This PR fixes the bug found when I ran `make test` on project. The problem is sometimes we cannot get the address info of remote socket (it doesn't matter why). `ssl_version_and_cipher_scan()` didn't handle this and we got error for nothing. New code fixes that by ignoring the exception and keep going on. `make test` output **before** changes:

```
(nettacker-py3.11) root@2cffc506e9ef:/usr/src/owaspnettacker# make test
poetry run pytest
================================================================================================================================================================== test session starts ===================================================================================================================================================================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
rootdir: /usr/src/owaspnettacker
configfile: pyproject.toml
testpaths: tests
plugins: xdist-3.6.1, cov-6.0.0
104 workers [23 items]
.....................xF                                                                                                                                                                                                                                                                                                                            [100%]
======================================================================================================================================================================== FAILURES ========================================================================================================================================================================
___________________________________________________________________________________________________________________________________________________ TestSocketMethod.test_ssl_version_and_cipher_scan ____________________________________________________________________________________________________________________________________________________
[gw0] linux -- Python 3.11.10 /root/.cache/pypoetry/virtualenvs/nettacker-R9-qgo07-py3.11/bin/python

self = <test_ssl.TestSocketMethod testMethod=test_ssl_version_and_cipher_scan>, mock_connection = <MagicMock name='create_tcp_socket' id='139700456825232'>, mock_ssl_check = <MagicMock name='is_weak_ssl_version' id='139700456840912'>, mock_cipher_check = <MagicMock name='is_weak_cipher_suite' id='139700456846288'>

    @patch("nettacker.core.lib.ssl.is_weak_cipher_suite")
    @patch("nettacker.core.lib.ssl.is_weak_ssl_version")
    @patch("nettacker.core.lib.ssl.create_tcp_socket")
    def test_ssl_version_and_cipher_scan(self, mock_connection, mock_ssl_check, mock_cipher_check):
        library = SslLibrary()
        HOST = "example.com"
        PORT = 80
        TIMEOUT = 60

        mock_connection.return_value = (MockConnectionObject(HOST, "TLSv1.3"), True)
        mock_ssl_check.return_value = ("TLSv1.3", False)
        mock_cipher_check.return_value = (["HIGH"], False)
        self.assertEqual(
>           library.ssl_version_and_cipher_scan(HOST, PORT, TIMEOUT),
            {
                "ssl_flag": True,
                "service": "http",
                "weak_version": False,
                "ssl_version": "TLSv1.3",
                "peer_name": "example.com",
                "cipher_suite": ["HIGH"],
                "weak_cipher_suite": False,
                "issuer": "NA",
                "subject": "NA",
                "expiration_date": "NA",
            },
        )

tests/core/lib/test_ssl.py:181:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nettacker/core/lib/ssl.py:188: in ssl_version_and_cipher_scan
    cert = ssl.get_server_certificate((host, port))
/usr/local/lib/python3.11/ssl.py:1563: in get_server_certificate
    with create_connection(addr, timeout=timeout) as sock:
/usr/local/lib/python3.11/socket.py:839: in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

host = 'example.com', port = 80, family = 0, type = <SocketKind.SOCK_STREAM: 1>, proto = 0, flags = 0

    def getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
        """Resolve host and port into list of address info entries.

        Translate the host/port argument into a sequence of 5-tuples that contain
        all the necessary arguments for creating a socket connected to that service.
        host is a domain name, a string representation of an IPv4/v6 address or
        None. port is a string service name such as 'http', a numeric port number or
        None. By passing None as the value of host and port, you can pass NULL to
        the underlying C API.

        The family, type and proto arguments can be optionally specified in order to
        narrow the list of addresses returned. Passing zero as a value for each of
        these arguments selects the full range of results.
        """
        # We override this function since we want to translate the numeric family
        # and socket type values to enum constants.
        addrlist = []
>       for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
E       socket.gaierror: [Errno -2] Name or service not known

/usr/local/lib/python3.11/socket.py:974: gaierror
------------------------------------------------------------------------------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------------------------------------------------------------------------------
True
==================================================================================================================================================================== warnings summary ====================================================================================================================================================================
nettacker/database/models.py:4: 104 warnings
  /usr/src/owaspnettacker/nettacker/database/models.py:4: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================================================================================ short test summary info =================================================================================================================================================================
FAILED tests/core/lib/test_ssl.py::TestSocketMethod::test_ssl_version_and_cipher_scan - socket.gaierror: [Errno -2] Name or service not known
================================================================================================================================================= 1 failed, 21 passed, 1 xfailed, 104 warnings in 13.38s =================================================================================================================================================
make: *** [Makefile:5: test] Error 1
```


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally


[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
