### PR TITLE
fix the create database part of postgresql.py

### DIFF
--- a/nettacker/database/postgresql.py
+++ b/nettacker/database/postgresql.py
@@ -10,7 +10,6 @@ def postgres_create_database():
     when using postgres database, this is the function that is used to
     create the database for the first time when you the nettacker run module.
     """
-
     try:
         engine = create_engine(
             "postgresql+psycopg2://{username}:{password}@{host}:{port}/{name}".format(
@@ -21,15 +20,14 @@ def postgres_create_database():
     except OperationalError:
         # if the database does not exist
         engine = create_engine(
-            "postgresql+psycopg2://{username}:{password}@{host}:{port}/{name}".format(
+            "postgresql+psycopg2://{username}:{password}@{host}:{port}/postgres".format(
                 **Config.db.as_dict()
             )
         )
         conn = engine.connect()
-        conn.execute("commit")
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
         conn.execute(text(f"CREATE DATABASE {Config.db.name}"))
         conn.close()
-
         engine = create_engine(
             "postgresql+psycopg2://{username}:{password}@{host}:{port}/{name}".format(
                 **Config.db.as_dict()


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Postgresql connected a database, and if it doesn't exist, it needs to create one before connecting to it (this was tried in the except block). Previous code was to connect to the same non-existent database and that won't work, instead we can connect to the default `postgres` database and create a new database from there.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
