### PR TITLE
robust handling of getservbyport() and filtered port detection

### DIFF
--- a/nettacker/core/lib/socket.py
+++ b/nettacker/core/lib/socket.py
@@ -73,7 +73,7 @@ class SocketLibrary(BaseLibrary):
                 service_name = socket.getservbyport(port)
             except OSError:
                 service_name = "unknown"
-            
+
             try:
                 socket_connection.send(b"ABC\x00\r\n\r\n\r\n" * 10)
                 response = socket_connection.recv(1024 * 1024 * 10)


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

The getservbyport() function relies on the `etc/services` file for default service resolution, however for non-default ports this fails and hence, even if response from that port is received, nettacker fails to report it (as it hits an error). 

Example demonstrated:
![image](https://github.com/user-attachments/assets/b510a8ec-68b1-4188-922a-cc4a36c06488)

This is port 8443 filtered. This port is not present in /etc/services file and hence nettacker gives,
![image](https://github.com/user-attachments/assets/984b29fa-4635-4602-af04-b8d8e8e363c2)

After the changes made here, Nettacker is able to classify the port as filtered as well. (by updating the `service` field)

![image](https://github.com/user-attachments/assets/2f71fd52-6aa0-43b9-a619-c7208d06309e)

This is using the same timeout value being previously used inside `create_tcp_socket()`.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
