### PR TITLE
regex fixes for mysql and mariaDB

### DIFF
--- a/nettacker/modules/scan/port.yaml
+++ b/nettacker/modules/scan/port.yaml
@@ -1047,11 +1047,11 @@ payloads:
                 reverse: false
 
               mariadb:
-                regex: "is not allowed to connect to this MariaDB server"
+                regex: "is not allowed to connect to this MariaDB server|mysql_native_password|\\d\\.\\d+\\.\\d+g?[a-zA-Z]*-MariaDB"
                 reverse: false
 
               mysql:
-                regex: "is not allowed to connect to this MySQL server|\\d\\.\\d+\\.\\d+g?[a-zA-Z]*"
+                regex: "is not allowed to connect to this MySQL server|\\d\\.\\d+\\.\\d+g?[a-zA-Z]*.*?caching_sha2_password"
                 reverse: false
 
               nntp:


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

1. The current regex for mysql (updated in PR #1062) is slightly incorrect because it will match any sequence of "digit.digit.digit" without ensuring if its really MySQL. I have updated this to include the "caching_sha2_password" plugin in the end with anything in between. This match only happens when the running service is MySQL.

![image](https://github.com/user-attachments/assets/691e8c4c-d6c6-45b4-a67e-bae6d256de6e)

3. The regex for mariaDB is also updated. This is done my matching "mysql_native_password" which is the native authentication plugin. Additionally, we check for a specific string like "digit.digit.digit-MariaDB" 

![image](https://github.com/user-attachments/assets/ed7fda22-4f4b-4597-a222-9dcfc46738bf)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Localization improvement
- [ ] Dependency upgrade
- [ ] Documentation improvement

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
