### PR TITLE
fixing the global flags issue in joomla_template_scan and drupal_theme_scan

### DIFF
--- a/nettacker/modules/scan/drupal_theme.yaml
+++ b/nettacker/modules/scan/drupal_theme.yaml
@@ -37,5 +37,5 @@ payloads:
           condition_type: or
           conditions:
             content:
-              regex: \/(?i)\bthemes\b\/(.+?)\/
+              regex: (?i)\/\bthemes\b\/(.+?)\/
               reverse: false

--- a/nettacker/modules/scan/joomla_template.yaml
+++ b/nettacker/modules/scan/joomla_template.yaml
@@ -40,5 +40,5 @@ payloads:
           condition_type: or
           conditions:
             content:
-              regex: \/(?i)\badministrator\/templates\b\/(.+?)\/|\/(?i)templates\/(.+?)\/
+              regex: (?i)\/\badministrator\/templates\b\/(.+?)\/|\/templates\/(.+?)\/
               reverse: false

--- a/tests/test_yaml_regexes.py
+++ b/tests/test_yaml_regexes.py
@@ -1,10 +1,14 @@
 import os
 import re
-import yaml
+
 import pytest
+import yaml
 
 BASE_DIRS = ["nettacker/modules/vuln", "nettacker/modules/scan"]
-DUMMY_TEST_STRING = "This is a random string for testing regex 220-You are user number HTTP/1.1 200 OK"
+DUMMY_TEST_STRING = (
+    "This is a random string for testing regex 220-You are user number HTTP/1.1 200 OK"
+)
+
 
 def get_yaml_files():
     for base in BASE_DIRS:
@@ -12,9 +16,11 @@ def get_yaml_files():
             if file.endswith(".yaml"):
                 yield os.path.join(base, file)
 
+
 def load_yaml(file_path):
     with open(file_path, "r") as f:
         return yaml.safe_load(f)
+
 
 def extract_http_regexes(payloads):
     regexes = []
@@ -26,6 +32,7 @@ def extract_http_regexes(payloads):
             if "content" in conditions and "regex" in conditions["content"]:
                 regexes.append(conditions["content"]["regex"])
     return regexes
+
 
 def extract_socket_regexes(file_name, payloads):
     regexes = []
@@ -49,13 +56,15 @@ def extract_socket_regexes(file_name, payloads):
 
     return regexes
 
+
 def is_valid_regex(regex: str) -> bool:
     try:
         pattern = re.compile(regex)
         re.findall(pattern, DUMMY_TEST_STRING)
         return True
-    except Exception as e:
+    except Exception:
         return False
+
 
 @pytest.mark.parametrize("yaml_file", list(get_yaml_files()))
 def test_yaml_regexes_valid(yaml_file):

--- a/tests/test_yaml_regexes.py
+++ b/tests/test_yaml_regexes.py
@@ -1,0 +1,78 @@
+import os
+import re
+import yaml
+import pytest
+
+BASE_DIRS = ["nettacker/modules/vuln", "nettacker/modules/scan"]
+DUMMY_TEST_STRING = "This is a random string for testing regex 220-You are user number HTTP/1.1 200 OK"
+
+def get_yaml_files():
+    for base in BASE_DIRS:
+        for file in os.listdir(base):
+            if file.endswith(".yaml"):
+                yield os.path.join(base, file)
+
+def load_yaml(file_path):
+    with open(file_path, "r") as f:
+        return yaml.safe_load(f)
+
+def extract_http_regexes(payloads):
+    regexes = []
+    for payload in payloads:
+        if payload.get("library") != "http":
+            continue
+        for step in payload.get("steps", []):
+            conditions = step.get("response", {}).get("conditions", {})
+            if "content" in conditions and "regex" in conditions["content"]:
+                regexes.append(conditions["content"]["regex"])
+    return regexes
+
+def extract_socket_regexes(file_name, payloads):
+    regexes = []
+
+    for payload in payloads:
+        if payload.get("library") != "socket":
+            continue
+        for step in payload.get("steps", []):
+            conditions = step.get("response", {}).get("conditions", {})
+
+            if "service" in conditions:  # for port.yaml
+                services = conditions["service"]
+                for service_block in services.values():
+                    if isinstance(service_block, dict) and "regex" in service_block:
+                        regexes.append(service_block["regex"])
+
+            elif "time_response" in conditions:  # for icmp.yaml
+                tr = conditions["time_response"]
+                if isinstance(tr, dict) and "regex" in tr:
+                    regexes.append(tr["regex"])
+
+    return regexes
+
+def is_valid_regex(regex: str) -> bool:
+    try:
+        pattern = re.compile(regex)
+        re.findall(pattern, DUMMY_TEST_STRING)
+        return True
+    except Exception as e:
+        return False
+
+@pytest.mark.parametrize("yaml_file", list(get_yaml_files()))
+def test_yaml_regexes_valid(yaml_file):
+    data = load_yaml(yaml_file)
+    payloads = data.get("payloads", [])
+
+    if not payloads:
+        pytest.skip(f"No payloads found in {yaml_file}")
+
+    if payloads[0].get("library") == "http":
+        regexes = extract_http_regexes(payloads)
+    elif payloads[0].get("library") == "socket":
+        file_name = os.path.basename(yaml_file)
+        regexes = extract_socket_regexes(file_name, payloads)
+    else:
+        pytest.skip(f"Unknown library type in {yaml_file}")
+        return
+
+    for regex in regexes:
+        assert is_valid_regex(regex), f"Invalid regex in {yaml_file}: `{regex}`"


### PR DESCRIPTION
…ns, and adding a regex validation testcase

<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Python doesn't support inline regex flags like (?i) to be anywhere but the start of the regex. This PR is to fix that. 

Additionally, this adds a test file to scans all regexes of yaml files inside `scan` and `vuln` based on what their library is (this condition was just to separate out port.yaml which has a slightly different yaml structure and goes inside socket.py)


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
