### PR TITLE
handle OSError if port not present in /etc/services

### DIFF
--- a/nettacker/core/lib/socket.py
+++ b/nettacker/core/lib/socket.py
@@ -49,22 +49,17 @@ class SocketLibrary(BaseLibrary):
         socket_connection.close()
 
         try:
-            known_service = socket.getservbyport(port)
+            service = socket.getservbyport(port)
         except OSError:
-            known_service = "unknown"
+            service = "unknown"
 
         return {
             "peer_name": peer_name,
-            "service": known_service,
+            "service": service,
             "ssl_flag": ssl_flag,
         }
 
     def tcp_connect_send_and_receive(self, host, port, timeout):
-        try:
-            known_service = socket.getservbyport(port)
-        except OSError:
-            known_service = "unknown"
-
         tcp_socket = create_tcp_socket(host, port, timeout)
         if tcp_socket is None:
             return None
@@ -83,10 +78,16 @@ class SocketLibrary(BaseLibrary):
                 response = b""
             except Exception:
                 response = b""
+
+        try:
+            service = socket.getservbyport(port)
+        except OSError:
+            service = "unknown"
+
         return {
             "peer_name": peer_name,
-            "service": known_service,
             "response": response.decode(errors="ignore"),
+            "service": service,
             "ssl_flag": ssl_flag,
         }
 


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

A shorter version of PR #1074. This is to handle unknown ports inside /etc/services, instead of not reporting that port as running, nettacker can call it "unknown"

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
