### PR TITLE
unicode encoding of special characters to avoid breaking WAF scans graph

### DIFF
--- a/nettacker/lib/graph/d3_tree_v1/engine.py
+++ b/nettacker/lib/graph/d3_tree_v1/engine.py
@@ -4,6 +4,15 @@ from nettacker.config import Config
 from nettacker.core.messages import messages
 
 
+def escape_for_html_js(json_str: str) -> str:
+    """
+    This is necessary because some payloads have HTML tags for XSS
+    as in waf.yaml, which break the HTML and output no graph. These are unicode escape
+    characters for the same
+    """
+    return json_str.replace("<", "\\u003C").replace(">", "\\u003E").replace("&", "\\u0026")
+
+
 def start(events):
     """
     generate the d3_tree_v1_graph with events
@@ -14,7 +23,6 @@ def start(events):
     Returns:
         a graph in HTML
     """
-
     # define  a normalised_json
     normalisedjson = {"name": "Started attack", "children": {}}
     # get data for normalised_json
@@ -41,7 +49,7 @@ def start(events):
     data = (
         open(Config.path.web_static_dir / "report/d3_tree_v1.html")
         .read()
-        .replace("__data_will_locate_here__", json.dumps(d3_structure))
+        .replace("__data_will_locate_here__", escape_for_html_js(json.dumps(d3_structure)))
         .replace("__title_to_replace__", messages("pentest_graphs"))
         .replace("__description_to_replace__", messages("graph_message"))
         .replace("__html_title_to_replace__", messages("nettacker_report"))


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Currently, the WAF scan has an xss parameter that is passed directly to the fuzzer for scans. However, this breaks the graph output in HTML because of the unescaped HTML script tags `<script>` present in that parameter.
![image](https://github.com/user-attachments/assets/af6435bb-cb0d-4485-a02d-f970169d0ffa)

To fix this, I added a unicode replacement for the tags, which will allow nettacker to use the same parameter and not affect the scans, while also making the graph work.

BEFORE
![image](https://github.com/user-attachments/assets/6ebf871e-58b8-4821-b092-6615b9f7826d)

UPDATED
![image](https://github.com/user-attachments/assets/7a23d835-a539-4199-878c-fa6d466f53ca)


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
