### PR TITLE
docs: Add Quick Start CLI usage section to index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,3 +8,49 @@ This documentation is generated using [mkdocs.org](https://www.mkdocs.org) and [
 OWASP Nettacker is an automated penetration testing framework designed to help cyber security professionals and ethical hackers perform reconnaissance, vulnerability assessments, and network security audits efficiently. Nettacker automates information gathering, vulnerability scanning, and credential brute forcing tasks, making it a powerful tool for identifying weaknesses in networks, web applications, IoT devices and APIs.
 
 Documentation [Home](Home.md)
+
+## 🔧 Quick Start
+
+Here are some common usage examples to help you get started with OWASP Nettacker:
+
+```bash
+# Basic port scan on a public target
+python nettacker.py -i scanme.nmap.org -m port_scan
+
+# Run all modules on a local IP
+python nettacker.py -i 192.168.1.1 --modules all
+
+# Scan using a built-in profile
+python nettacker.py -i example.com --profile scan -v
+
+# Save results as JSON with graph output
+python nettacker.py -i example.com -m port_scan -o results.json --graph d3_tree
+
+# Scan multiple targets listed in a file
+python nettacker.py -T targets.txt -m subdomain_scan
+Use --help to explore more flags:
+
+bash
+Copy
+Edit
+python nettacker.py --help
+Nettacker is fully modular — customize scans using config files, profiles, or manual flags.
+
+yaml
+Copy
+Edit
+
+---
+
+## 📍 Where to Put This in `index.md`
+
+- Ideally after the introduction or before the long table of flags/config
+- Or at the very top if there’s no content yet
+- You can add a new heading like:
+
+```md
+# Nettacker Documentation
+Welcome to OWASP Nettacker...
+
+## 🔧 Quick Start
+...


### PR DESCRIPTION
## Proposed change
Added a "Quick Start" section to `docs/index.md` with simple, beginner-friendly examples for running Nettacker from the command line.

## Type of change
- [x] Documentation/localization improvement

## Checklist
- [x] I've followed the contributing guidelines
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Quick Start" section with practical usage examples and command-line snippets for OWASP Nettacker.
  * Included guidance on integrating the new section within the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->