### PR TITLE
Fixed the issue of select all profiles button

### DIFF
--- a/nettacker/web/static/index.html
+++ b/nettacker/web/static/index.html
@@ -172,9 +172,9 @@
                 <h3>Profiles</h3>
                 <div class="form-group">
                     <div id="profiles" class="checkbox text-justify">
-                        <label><input id="all" type="checkbox" class="check check-all-scans"><a
-                                class="label label-info">Select all profiles</a></label>&nbsp;&nbsp;&nbsp;&nbsp;
-                        {% autoescape off %}{{profile}}{% endautoescape %}
+            <label><input id="all_profiles" type="checkbox" class="check check-all-profiles"><a
+                class="label label-info">Select all profiles</a></label>&nbsp;&nbsp;&nbsp;&nbsp;
+            {% autoescape off %}{{profile}}{% endautoescape %}
                     </div>
                 </div>
                 <h3>Scan Methods</h3>
@@ -299,7 +299,7 @@
                             <input id="exclude_ports" type="text" class="form-control"
                                    placeholder="e.g., 80,443,8080">
                         </div>
-                    </div>
+                    </div>  
 
                     <!-- HTTP Headers -->
                     <div class="col-md-6">

--- a/nettacker/web/static/js/main.js
+++ b/nettacker/web/static/js/main.js
@@ -351,8 +351,10 @@ $(document).ready(function () {
     var p = [];
     var n = 0;
     $("#profiles input:checked").each(function () {
-      p[n] = this.id;
-      n += 1;
+      if (this.id !== "all_profiles") {
+        p[n] = this.id;
+        n += 1;
+      }
     });
     var profiles = p.join(",");
 

--- a/nettacker/web/static/js/main.js
+++ b/nettacker/web/static/js/main.js
@@ -676,6 +676,10 @@ $(document).ready(function () {
     $(".checkbox-vuln-module").prop("checked", $(this).prop("checked"));
   });
 
+  $(".check-all-profiles").click(function () {
+    $("#profiles input[type='checkbox']").not(this).prop("checked", $(this).prop("checked"));
+  });
+
   $(".check-all-scans").click(function () {
     $(".checkbox-brute-module").prop("checked", $(this).prop("checked"));
     $(".checkbox-scan-module").prop("checked", $(this).prop("checked"));


### PR DESCRIPTION
Earlier `select all profiles` was selecting every `scan methods`  instead of profiles, fixed it now.

## Proposed change
### File changed while fixing
`nettacker/web/static/index.html`
`nettacker/web/static/js/main.js`

Solves the issue #1116

I was working on the issue #781, and I first observe this glitch so thought it would be better to create a separate issue of this and make PR for this as this issue is a bit off track from issue #781.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "select/deselect all" option for profile checkboxes in the scan form, allowing users to quickly select or clear all profiles at once.

* **Style**
  * Updated the identifier and CSS class for the "select all profiles" checkbox to improve clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->