### PR TITLE
New module: adobe_aem_lastpatcheddate_scan

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -8,6 +8,7 @@ OWASP Nettacker Modules can be of type **Scan** (scan for something), **Vuln** (
 
 ## Scan Modules
 
+* '**adobe_aem_lastpatcheddate_scan**' - Scan the target for Adobe Experience Manager (AEM) and return its last patched date
 * '**admin_scan**'  - Scan the target for various Admin folders such as /admin /phpmyadmin /cmsadmin /wp-admin etc
 * '**citrix_lastpatcheddate_scan**'  Scan the target and try to detect Citrix Netscaler Gateway and it's last patched date
 * '**cms_detection_scan**' - Scan the target and try to detect the CMS (Wordpress, Drupal or Joomla) using response fingerprinting

--- a/nettacker/modules/scan/adobe_aem_lastpatcheddate.yaml
+++ b/nettacker/modules/scan/adobe_aem_lastpatcheddate.yaml
@@ -38,7 +38,7 @@ payloads:
                 - 8443
         response:
           condition_type: and
-          log: "response_dependent['headers']['Last-Modified']"
+          log: "response_dependent['headers']['last-modified']"
           conditions:
             status_code:
               regex: "200"

--- a/nettacker/modules/scan/adobe_aem_lastpatcheddate.yaml
+++ b/nettacker/modules/scan/adobe_aem_lastpatcheddate.yaml
@@ -24,7 +24,7 @@ payloads:
             input_format: "{{schema}}://{target}:{{ports}}/libs/granite/core/content/login/clientlib.js"
             prefix: ""
             suffix: ""
-            interceptors:
+            interceptors: []
             data:
               schema:
                 - "http"
@@ -32,6 +32,10 @@ payloads:
               ports:
                 - 80
                 - 443
+                - 4502
+                - 4503
+                - 8080
+                - 8443
         response:
           condition_type: and
           log: "response_dependent['headers']['Last-Modified']"

--- a/nettacker/modules/scan/adobe_aem_lastpatcheddate.yaml
+++ b/nettacker/modules/scan/adobe_aem_lastpatcheddate.yaml
@@ -1,0 +1,48 @@
+info:
+  name: adobe_aem_lastpatcheddate_scan
+  author: OWASP Nettacker Team
+  severity: 3
+  description: Adobe Experience Manager (AEM) Last Patched Date Scan
+  reference:
+  profiles:
+    - scan
+    - http
+    - adobe
+    - low_severity
+
+payloads:
+  - library: http
+    steps:
+      - method: head
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/libs/granite/core/content/login/clientlib.js"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+        response:
+          condition_type: and
+          log: "response_dependent['headers']['Last-Modified']"
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            headers:
+              Last-Modified:
+                regex: .*  
+                reverse: false
+              Content-Type: 
+                regex: "javascript"
+                reverse: false


### PR DESCRIPTION
New module: adobe_aem_lastpatcheddate_scan - Scan the target for Adobe Experience Manager (AEM) and return its last patched date

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [x] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally
