### PR TITLE
pyproject updates to fix warnings issued by pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,10 @@ profile = "black"
 [tool.pytest.ini_options]
 addopts = "--cov=nettacker --cov-config=pyproject.toml --cov-report term --cov-report xml --dist loadscope --no-cov-on-fail --numprocesses auto"
 testpaths = ["tests"]
+markers = [
+    "asyncio: mark test as async"
+]
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 line-length = 99


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Currently the pytest configurations do not set the default loop scopes for asyncio. pytest-asyncio was introduced as a new dependency in #1107. This PR is to set the defaults and the markers for pytest-asyncio
## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [x] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
