### PR TITLE
Allow running on FreeBSD 13.*, 14.* and 15.*

### DIFF
--- a/nettacker/core/app.py
+++ b/nettacker/core/app.py
@@ -66,7 +66,7 @@ class Nettacker(ArgParser):
         log.reset_color()
 
     def check_dependencies(self):
-        if sys.platform not in {"darwin", "linux", "freebsd13", "freebsd14", "freebsd15"}:
+        if sys.platform not in {"darwin", "freebsd13", "freebsd14", "freebsd15", "linux"}:
             die_failure(_("error_platform"))
 
         try:


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

I've tested running on FreeBSD 13.5 and 14.3 and communicated on Slack. There don't seem to be any problems with running on FreeBSD.

I want to submit a [FreeBSD port](https://www.freshports.org/) for Nettacker, so it can easily be installed and run on FreeBSD.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [x] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
