### PR TITLE
Add Windows Compatibility support

### DIFF
--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -379,6 +379,7 @@ def get_result_content():
     Returns:
         content of the scan result
     """
+    from pathlib import Path 
     api_key_is_valid(app, flask_request)
     scan_id = get_value(flask_request, "id")
     if not scan_id:
@@ -388,11 +389,10 @@ def get_result_content():
         filename, file_content = get_scan_result(scan_id)
     except Exception:
         return jsonify(structure(status="error", msg="database error!")), 500
-
     return Response(
         file_content,
         mimetype=mime_types().get(os.path.splitext(filename)[1], "text/plain"),
-        headers={"Content-Disposition": "attachment;filename=" + filename.split("/")[-1]},
+        headers={"Content-Disposition": "attachment;filename=" + Path(filename).name},
     )
 
 

--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -7,6 +7,7 @@ import string
 import time
 from threading import Thread
 from types import SimpleNamespace
+from pathlib import Path
 
 from flask import Flask, jsonify
 from flask import request as flask_request
@@ -379,16 +380,16 @@ def get_result_content():
     Returns:
         content of the scan result
     """
-    from pathlib import Path 
     api_key_is_valid(app, flask_request)
     scan_id = get_value(flask_request, "id")
     if not scan_id:
         return jsonify(structure(status="error", msg=_("invalid_scan_id"))), 400
-
+    
     try:
         filename, file_content = get_scan_result(scan_id)
     except Exception:
         return jsonify(structure(status="error", msg="database error!")), 500
+    
     return Response(
         file_content,
         mimetype=mime_types().get(os.path.splitext(filename)[1], "text/plain"),

--- a/nettacker/core/app.py
+++ b/nettacker/core/app.py
@@ -186,7 +186,7 @@ class Nettacker(ArgParser):
                 self.start_scan(scan_id)
                 self.arguments.selected_modules = selected_modules
                 if "icmp_scan" in self.arguments.selected_modules:
-                        self.arguments.selected_modules.remove("icmp_scan")
+                    self.arguments.selected_modules.remove("icmp_scan")
                 self.arguments.targets = self.filter_target_by_event(targets, scan_id, "icmp_scan")
             else:
                 log.warn(_("icmp_need_root_access"))

--- a/nettacker/core/arg_parser.py
+++ b/nettacker/core/arg_parser.py
@@ -1,5 +1,6 @@
 import json
 import sys
+from pathlib import Path
 from argparse import ArgumentParser
 
 import yaml
@@ -48,10 +49,9 @@ class ArgParser(ArgumentParser):
         Returns:
             an array of graph names
         """
-
         graph_names = []
         for graph_library in Config.path.graph_dir.glob("*/engine.py"):
-            graph_names.append(str(graph_library).split("/")[-2] + "_graph")
+            graph_names.append(graph_library.parent.name + "_graph")
         return list(set(graph_names))
 
     @staticmethod
@@ -62,13 +62,13 @@ class ArgParser(ArgumentParser):
         Returns:
             an array of languages
         """
+        from pathlib import Path  
         languages_list = []
 
         for language in Config.path.locale_dir.glob("*.yaml"):
-            languages_list.append(str(language).split("/")[-1].split(".")[0])
+            languages_list.append(Path(language).stem)  # .stem gets filename without extension
 
         return list(set(languages_list))
-
     @staticmethod
     def load_modules(limit=-1, full_details=False):
         """
@@ -80,11 +80,13 @@ class ArgParser(ArgumentParser):
         Returns:
             an array of all module names
         """
+        from pathlib import Path  
         # Search for Modules
         module_names = {}
         for module_name in sorted(Config.path.modules_dir.glob("**/*.yaml")):
-            library = str(module_name).split("/")[-1].split(".")[0]
-            category = str(module_name).split("/")[-2]
+            module_path = Path(module_name)
+            library = module_path.stem  # Gets filename without extension
+            category = module_path.parent.name  # Gets parent directory name
             module = f"{library}_{category}"
             contents = yaml.safe_load(TemplateLoader(module).open().split("payload:")[0])
             module_names[module] = contents["info"] if full_details else None
@@ -100,7 +102,6 @@ class ArgParser(ArgumentParser):
         module_names["all"] = {}
 
         return module_names
-
     @staticmethod
     def load_profiles(limit=-1):
         """

--- a/nettacker/core/arg_parser.py
+++ b/nettacker/core/arg_parser.py
@@ -61,14 +61,13 @@ class ArgParser(ArgumentParser):
 
         Returns:
             an array of languages
-        """
-        from pathlib import Path  
+        """ 
         languages_list = []
 
         for language in Config.path.locale_dir.glob("*.yaml"):
-            languages_list.append(Path(language).stem)  # .stem gets filename without extension
-
+            languages_list.append(Path(language).stem)  
         return list(set(languages_list))
+    
     @staticmethod
     def load_modules(limit=-1, full_details=False):
         """
@@ -79,14 +78,13 @@ class ArgParser(ArgumentParser):
 
         Returns:
             an array of all module names
-        """
-        from pathlib import Path  
+        """ 
         # Search for Modules
         module_names = {}
         for module_name in sorted(Config.path.modules_dir.glob("**/*.yaml")):
             module_path = Path(module_name)
-            library = module_path.stem  # Gets filename without extension
-            category = module_path.parent.name  # Gets parent directory name
+            library = module_path.stem  
+            category = module_path.parent.name  
             module = f"{library}_{category}"
             contents = yaml.safe_load(TemplateLoader(module).open().split("payload:")[0])
             module_names[module] = contents["info"] if full_details else None
@@ -102,6 +100,7 @@ class ArgParser(ArgumentParser):
         module_names["all"] = {}
 
         return module_names
+    
     @staticmethod
     def load_profiles(limit=-1):
         """

--- a/nettacker/core/template.py
+++ b/nettacker/core/template.py
@@ -31,8 +31,7 @@ class TemplateLoader:
         module_name_parts = self.name.split("_")
         action = module_name_parts[-1]
         library = "_".join(module_name_parts[:-1])
-
-        # TEMP FIX FOR TESTING - Explicitly specify UTF-8 encoding for Windows
+        
         with open(Config.path.modules_dir / action / f"{library}.yaml", encoding='utf-8') as yaml_file:
             return yaml_file.read()
 

--- a/nettacker/core/template.py
+++ b/nettacker/core/template.py
@@ -32,7 +32,8 @@ class TemplateLoader:
         action = module_name_parts[-1]
         library = "_".join(module_name_parts[:-1])
 
-        with open(Config.path.modules_dir / action / f"{library}.yaml") as yaml_file:
+        # TEMP FIX FOR TESTING - Explicitly specify UTF-8 encoding for Windows
+        with open(Config.path.modules_dir / action / f"{library}.yaml", encoding='utf-8') as yaml_file:
             return yaml_file.read()
 
     def format(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ requests = "^2.32.3"
 sqlalchemy = "^2.0.22"
 texttable = "^1.7.0"
 zipp = "^3.19.1"
-uvloop = "^0.21.0"
+uvloop = {version = "^0.21.0", markers = "sys_platform != 'win32'"}
 pymysql = "^1.1.1"
 impacket = "^0.11.0"
 


### PR DESCRIPTION
## Proposed change

This PR adds Windows compatibility to OWASP Nettacker by addressing platform-specific issues that previously prevented it from running on Windows systems.

**Changes include:**
- Made `uvloop` dependency conditional using platform markers (doesn't support Windows)
- Added `win32` to allowed platforms in platform check
- Implemented cross-platform privilege checking to replace Unix-only `os.geteuid()`
- Added explicit UTF-8 encoding for file operations
- Replaced hardcoded path separators with pathlib for cross-platform compatibility

**Testing:**
Successfully tested on Windows 11 with Python 3.12:
- Installation completes without errors
- All functionality works (help menu, scanning, report generation)

Resolves #[933]

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

Tested manually on windows since make commands are unix specific.

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/