### PR TITLE
Refactor: Correct 'vuln' tag for 5 SSL modules

### DIFF
--- a/nettacker/modules/vuln/ssl_certificate_weak_signature.yaml
+++ b/nettacker/modules/vuln/ssl_certificate_weak_signature.yaml
@@ -6,7 +6,7 @@ info:
   reference:
     - https://www.ssl.com/article/ssl-tls-self-signed-certificates/
   profiles:
-    - scan
+    - vuln
     - ssl
 
 payloads:

--- a/nettacker/modules/vuln/ssl_expired_certificate.yaml
+++ b/nettacker/modules/vuln/ssl_expired_certificate.yaml
@@ -6,7 +6,7 @@ info:
   reference:
     - https://www.beyondsecurity.com/resources/vulnerabilities/ssl-certificate-expiry
   profiles:
-    - scan
+    - vuln
     - ssl
 
 payloads:

--- a/nettacker/modules/vuln/ssl_self_signed_certificate.yaml
+++ b/nettacker/modules/vuln/ssl_self_signed_certificate.yaml
@@ -6,7 +6,7 @@ info:
   reference:
     - https://www.ssl.com/article/ssl-tls-self-signed-certificates/
   profiles:
-    - scan
+    - vuln
     - ssl
 
 payloads:

--- a/nettacker/modules/vuln/ssl_weak_cipher.yaml
+++ b/nettacker/modules/vuln/ssl_weak_cipher.yaml
@@ -7,7 +7,7 @@ info:
     - https://www.manageengine.com/privileged-access-management/help/ssl_vulnerability.html
     - https://www.acunetix.com/vulnerabilities/web/tls-ssl-weak-cipher-suites/
   profiles:
-    - scan
+    - vuln
     - ssl
 
 payloads:

--- a/nettacker/modules/vuln/ssl_weak_version.yaml
+++ b/nettacker/modules/vuln/ssl_weak_version.yaml
@@ -7,7 +7,7 @@ info:
     - https://www.manageengine.com/privileged-access-management/help/ssl_vulnerability.html
     - https://www.cloudflare.com/learning/ssl/why-use-tls-1.3/
   profiles:
-    - scan
+    - vuln
     - ssl
 
 payloads:


### PR DESCRIPTION
## Proposed change
Fixes #1161 
As discussed in the issue, this PR corrects the profile tags for 5 SSL modules from 'scan' to 'vuln' to match the module directory and function.

## Type of change

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
