### PR TITLE
perf(http): implement async batching for HTTP engine

### DIFF
--- a/nettacker/core/module.py
+++ b/nettacker/core/module.py
@@ -157,43 +157,66 @@ class Module:
                 importlib.import_module(f"nettacker.core.lib.{library.lower()}"),
                 f"{library.capitalize()}Engine",
             )()
-            for step in payload["steps"]:
-                for sub_step in step:
-                    thread = Thread(
-                        target=engine.run,
-                        args=(
-                            sub_step,
-                            self.module_name,
-                            self.target,
-                            self.scan_id,
-                            self.module_inputs,
-                            self.process_number,
-                            self.module_thread_number,
-                            self.total_module_thread_number,
-                            request_number_counter,
-                            total_number_of_requests,
-                        ),
+
+            # Check if engine supports batch processing (AsyncIO optimization)
+            if hasattr(engine, "run_batch"):
+                all_sub_steps = []
+                for step in payload["steps"]:
+                    for sub_step in step:
+                        all_sub_steps.append(sub_step)
+
+                if all_sub_steps:
+                    engine.run_batch(
+                        all_sub_steps,
+                        self.module_name,
+                        self.target,
+                        self.scan_id,
+                        self.module_inputs,
+                        self.process_number,
+                        self.module_thread_number,
+                        self.total_module_thread_number,
+                        request_number_counter,
+                        total_number_of_requests
                     )
-                    thread.name = f"{self.target} -> {self.module_name} -> {sub_step}"
-                    request_number_counter += 1
-                    log.verbose_event_info(
-                        _("sending_module_request").format(
-                            self.process_number,
-                            self.module_name,
-                            self.target,
-                            self.module_thread_number,
-                            self.total_module_thread_number,
-                            request_number_counter,
-                            total_number_of_requests,
+                    request_number_counter += len(all_sub_steps)
+            else:
+                for step in payload["steps"]:
+                    for sub_step in step:
+                        thread = Thread(
+                            target=engine.run,
+                            args=(
+                                sub_step,
+                                self.module_name,
+                                self.target,
+                                self.scan_id,
+                                self.module_inputs,
+                                self.process_number,
+                                self.module_thread_number,
+                                self.total_module_thread_number,
+                                request_number_counter,
+                                total_number_of_requests,
+                            ),
                         )
-                    )
-                    thread.start()
-                    time.sleep(self.module_inputs["time_sleep_between_requests"])
-                    active_threads.append(thread)
-                    wait_for_threads_to_finish(
-                        active_threads,
-                        maximum=self.module_inputs["thread_per_host"],
-                        terminable=True,
-                    )
+                        thread.name = f"{self.target} -> {self.module_name} -> {sub_step}"
+                        request_number_counter += 1
+                        log.verbose_event_info(
+                            _("sending_module_request").format(
+                                self.process_number,
+                                self.module_name,
+                                self.target,
+                                self.module_thread_number,
+                                self.total_module_thread_number,
+                                request_number_counter,
+                                total_number_of_requests,
+                            )
+                        )
+                        thread.start()
+                        time.sleep(self.module_inputs["time_sleep_between_requests"])
+                        active_threads.append(thread)
+                        wait_for_threads_to_finish(
+                            active_threads,
+                            maximum=self.module_inputs["thread_per_host"],
+                            terminable=True,
+                        )
 
         wait_for_threads_to_finish(active_threads, maximum=None, terminable=True)


### PR DESCRIPTION
Refactors HttpEngine and the core module loader to support batch processing of requests. Instead of spawning a thread-per-request and creating a new aiohttp.ClientSession for every probe, the engine now collects steps and processes them concurrently within a single shared session.

- Reduces TCP/TLS handshake overhead via connection pooling.

- Eliminates thread/event-loop creation noise.

- Significantly improves scan performance for HTTP-based modules.

<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
