### PR TITLE
Fix UnboundLocalError in graph.py when ModuleNotFoundError is caught

### DIFF
--- a/nettacker/core/graph.py
+++ b/nettacker/core/graph.py
@@ -46,6 +46,7 @@ def build_graph(graph_name, events):
         )
     except ModuleNotFoundError:
         die_failure(_("graph_module_unavailable").format(graph_name))
+        return
 
     log.info(_("finish_build_graph"))
     return start(events)
@@ -67,6 +68,7 @@ def build_compare_report(compare_results):
         )
     except ModuleNotFoundError:
         die_failure(_("graph_module_unavailable").format("compare_report"))
+        return
 
     log.info(_("finish_build_report"))
     return build_report(compare_results)

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -33,10 +33,10 @@ def test_build_graph_success(mock_import_module):
 
 @patch("nettacker.core.graph.die_failure")
 @patch("nettacker.core.graph.importlib.import_module", side_effect=ModuleNotFoundError)
-@pytest.mark.xfail(reason="It will hit an UnboundLocalError")
 def test_build_graph_module_not_found(mock_import_module, mock_die_failure):
-    build_graph("missing_graph", [])
+    result = build_graph("missing_graph", [])
     mock_die_failure.assert_called_once()
+    assert result is None
 
 
 @patch("nettacker.core.graph.importlib.import_module")
@@ -49,10 +49,10 @@ def test_build_compare_report_success(mock_import_module):
 
 @patch("nettacker.core.graph.die_failure")
 @patch("nettacker.core.graph.importlib.import_module", side_effect=ModuleNotFoundError)
-@pytest.mark.xfail(reason="It will hit an UnboundLocalError")
 def test_build_compare_report_module_not_found(mock_import_module, mock_die_failure):
-    build_compare_report({"some": "results"})
+    result = build_compare_report({"some": "results"})
     mock_die_failure.assert_called_once()
+    assert result is None
 
 
 @patch("nettacker.core.graph.merge_logs_to_list", return_value=["event1", "event2"])


### PR DESCRIPTION
## Description

This PR fixes the UnboundLocalError bug reported in #1198.

## Problem

The functions `build_graph()` and `build_compare_report()` in `nettacker/core/graph.py` had a bug where they would raise `UnboundLocalError` when `ModuleNotFoundError` was caught but `die_failure()` didn't actually exit the program (e.g., when mocked in tests).

## Solution

Added explicit `return` statements after `die_failure()` calls in both functions to ensure they don't continue execution and try to use variables that were never assigned.

## Changes Made

- **nettacker/core/graph.py**:
  - Added `return` statement after `die_failure()` in `build_graph()` (line 49)
  - Added `return` statement after `die_failure()` in `build_compare_report()` (line 71)

- **tests/core/test_graph.py**:
  - Removed `@pytest.mark.xfail` markers from `test_build_graph_module_not_found()` 
  - Removed `@pytest.mark.xfail` markers from `test_build_compare_report_module_not_found()`
  - Updated tests to verify functions return `None` after `die_failure()` is called

## Testing

The previously failing tests now pass:
- `test_build_graph_module_not_found()` - verifies `build_graph()` returns `None` instead of raising `UnboundLocalError`
- `test_build_compare_report_module_not_found()` - verifies `build_compare_report()` returns `None` instead of raising `UnboundLocalError`

## Impact

- Fixes test failures that were marked as expected failures
- Improves code robustness and testability
- No impact on production behavior (die_failure still calls sys.exit)
- Makes error handling more predictable

Fixes #1198