### PR TITLE
add Grafana CVE-2025-4123 vulnerability module

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -202,6 +202,7 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 - '**forgerock_am_cve_2021_35464_vuln**' – check the target for ForgeRock AM CVE-2021-35464
 - '**galera_webtemp_cve_2021_40960_vuln**' – check the target for Galera WebTemplate CVE-2021-40960
 - '**grafana_cve_2021_43798_vuln**' – check the target for Grafana CVE-2021-43798 vulnerability
+- '**grafana_cve_2025_4123_vuln**' – check the target for Grafana CVE-2025-4123 vulnerability
 - '**graphql_vuln**' – check the target for exposed GraphQL introspection endpoint
 - '**gurock_testrail_cve_2021_40875_vuln**' – check the target for TestRail CVE-2021-40875 vulnerability
 - '**hoteldruid_cve_2021_37833_vuln**' – check the target for HotelDruid CVE-2021-37833 XSS vulnerability

--- a/nettacker/modules/vuln/grafana_cve_2025_4123.yaml
+++ b/nettacker/modules/vuln/grafana_cve_2025_4123.yaml
@@ -1,0 +1,60 @@
+info:
+  name: grafana_cve_2025_4123_vuln
+  author: Swarnim Bandekar
+  severity: 6.1
+  description: >
+    Grafana XSS / Open Redirect / SSRF via Client Path Traversal (CVE-2025-4123).
+    The staticHandler in vulnerable Grafana versions incorrectly redirects
+    directory requests, allowing path traversal to redirect users to an
+    attacker-controlled domain. This can be chained with frontend plugin
+    loading for XSS and, if Image Renderer is installed, full-read SSRF.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-4123
+    - https://grafana.com/security/security-advisories/cve-2025-4123/
+  profiles:
+    - vuln
+    - http
+    - grafana
+    - cve2025
+    - cve
+    - open_redirect
+    - medium_severity
+
+payloads:
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/{{request_path}}"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 3000
+                - 80
+                - 443
+              request_path:
+                - "public/..%2F%5cexample.com%2F%3f%2F..%2F.."
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "302"
+              reverse: false
+            headers:
+              Location:
+                regex: ".*example\\.com.*"
+                reverse: false
+            content:
+              regex: "<a href=\".*example\\.com.*\">"
+              reverse: false


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This pull request adds a new OWASP Nettacker vulnerability module to detect **Grafana CVE-2025-4123**, which allows open redirect and can be chained with SSRF or XSS via client path traversal.

The module is based on public advisories and verified detection logic, adapted from the official Grafana security release and existing community research. It follows Nettacker module standards and has been tested locally against a vulnerable setup.

References:
- https://grafana.com/blog/2025/05/21/grafana-security-release-high-severity-security-fix-for-cve-2025-4123/
- https://nvd.nist.gov/vuln/detail/CVE-2025-4123

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [x] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

@securestep9 
@arkid15r 

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
