### PR TITLE
added n8n RCE vulnerability module for CVE-2026-21858

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -147,6 +147,7 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 - '**geoserver_cve_2024_36401_vuln**' - check the target for CVE-2024-36401 vulnerability
 - '**heartbleed_vuln**' - check SSL for Heartbleed vulnerability (CVE-2014-0160)
 - '**msexchange_cve_2021_26855**' - check the target for MS Exchange SSRF CVE-2021-26855 (proxylogon/hafnium)
+- '**n8n_cve_2026_21858_vuln**' - check the target for n8n CVE-2026-21858 Content-Type confusion RCE and related CVEs (CVE-2025-68613, CVE-2025-68668, CVE-2026-21877)
 - '**nextjs_cve_2025_55182_vuln**' - check the target for CVE-2025-55182(React2Shell)
 - '**http_cors_vuln**' - check the web server for overly-permissive CORS (header 'Access-Control-Allow-Origin'=\*)
 - '**joomla_cve_2023_23752_vuln**' - check the target for Joomla CVE-2023-23752 information disclosure vulnerability

--- a/nettacker/modules/vuln/n8n_cve_2026_21858.yaml
+++ b/nettacker/modules/vuln/n8n_cve_2026_21858.yaml
@@ -6,9 +6,8 @@ info:
     n8n workflow automation platform versions 1.65.0 through 1.120.x are affected by
     CVE-2026-21858, a critical Content-Type confusion vulnerability in webhook endpoints 
     allowing Remote Code Execution (CVSS 10.0). This module detects vulnerable n8n
-    instances by fingerprinting the versionCli field in the /rest/settings endpoint and
-    subsequently probing to confirm that webhook endpoints are active and reachable.
-    Upgrade to n8n >= 1.121.0.
+    instances by fingerprinting the versionCli field in the /rest/settings endpoint.
+    Version-based detection only; no webhook exploitation is performed. Upgrade to n8n >= 1.121.0.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-21858
     - https://thehackernews.com/2026/01/critical-n8n-vulnerability-cvss-100.html

--- a/nettacker/modules/vuln/n8n_cve_2026_21858.yaml
+++ b/nettacker/modules/vuln/n8n_cve_2026_21858.yaml
@@ -1,0 +1,60 @@
+info:
+  name: n8n_cve_2026_21858_vuln
+  author: Swarnim Bandekar
+  severity: 10
+  description: >
+    n8n workflow automation platform versions 1.65.0 through 1.120.x are affected by
+    CVE-2026-21858, a critical Content-Type confusion vulnerability in webhook endpoints 
+    allowing Remote Code Execution (CVSS 10.0). This module detects vulnerable n8n
+    instances by fingerprinting the versionCli field in the /rest/settings endpoint and
+    subsequently probing to confirm that webhook endpoints are active and reachable.
+    Upgrade to n8n >= 1.121.0.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-21858
+    - https://thehackernews.com/2026/01/critical-n8n-vulnerability-cvss-100.html
+  profiles:
+    - vuln
+    - http
+    - critical_severity
+    - cve2026
+    - cve
+    - n8n
+    - rce
+
+payloads:
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/rest/settings"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+                - 5678
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            headers:
+              Content-Type:
+                regex: application/json
+                reverse: false
+            content:
+              regex: "\"versionCli\":\\s*\"1\\.(?:6[5-9]|[7-9][0-9]|1[01][0-9]|120)\\.[0-9]+\""
+              reverse: false
+          log: "n8n instance with vulnerable version detected (CVE-2026-21858)"


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Added a new vulnerability module [n8n_cve_2026_21858.yaml](cci:7://file:///c:/Users/swarn/Desktop/Nettacker/nettacker/modules/vuln/n8n_cve_2026_21858.yaml:0:0-0:0) to detect **CVE-2026-21858 (n8n Webhooks - Remote Code Execution)**.

**Detection Logic:**
- Targets the unauthenticated `/rest/settings` API endpoint which exposes the instance version.
- Uses a precise regex `1\.(?:6[5-9]|[7-9][0-9]|1[01][0-9]|120)\.[0-9]+` to strictly match potentially vulnerable versions between `1.65.0` and `1.121.0` (exclusive).
- Includes the default n8n port **5678** in the scan list alongside 80 and 443.
- Dynamically logs the detected version in the scan output for validation.

**References:**
- https://nvd.nist.gov/vuln/detail/CVE-2026-21858
- https://thehackernews.com/2026/01/critical-n8n-vulnerability-cvss-100.html

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [x] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

@securestep9 @arkid15r 

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/