### PR TITLE
l10n: add Portuguese (pt-br) translations for comparison messages

### DIFF
--- a/nettacker/locale/pt-br.yaml
+++ b/nettacker/locale/pt-br.yaml
@@ -279,3 +279,8 @@ no_event_found: nenhum evento encontrado nesse escaneio
 invalid_json_type_to_db: >-
   Tipo inválido de dados JSON para o banco de dados. Pulando a submissão para
   obanco de dados. Dado:{0}
+compare_report_path_filename: o caminho do arquivo para armazenar o relatório de comparação de escaneio
+no_scan_to_compare: o scan_id a ser comparado não foi encontrado
+compare_report_saved: 'resultados da comparação salvos em {0}'
+build_compare_report: construindo relatório de comparação
+finish_build_report: Concluída a construção do relatório de comparação


### PR DESCRIPTION
## Proposed change

Contributes to #905

This PR adds missing Portuguese (Brazil) translations for comparison functionality messages.

## Translations Added

The following 5 keys have been translated to Portuguese (pt-br):

- `compare_report_path_filename`: "o caminho do arquivo para armazenar o relatório de comparação de escaneio"
- `no_scan_to_compare`: "o scan_id a ser comparado não foi encontrado"
- `compare_report_saved`: "resultados da comparação salvos em {0}"
- `build_compare_report`: "construindo relatório de comparação"
- `finish_build_report`: "Concluída a construção do relatório de comparação"

## Type of change

- [x] Documentation/localization improvement

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

## Translation Quality

All translations were carefully crafted to:
- Maintain consistency with existing Portuguese translations in the file
- Preserve the `{0}` placeholder in `compare_report_saved` for variable substitution
- Follow Brazilian Portuguese conventions
- Match the tone and style of other messages in the locale file

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/