### PR TITLE
fix: Add regex validation to prevent IndexError in SOCKS proxy parser

### DIFF
--- a/nettacker/core/socks_proxy.py
+++ b/nettacker/core/socks_proxy.py
@@ -1,4 +1,8 @@
+import re
 import socket
+
+from nettacker.core.die import die_failure
+from nettacker.core.messages import messages as _
 
 
 def getaddrinfo(*args):
@@ -20,22 +24,29 @@ def set_socks_proxy(socks_proxy):
 
         socks_version = socks.SOCKS5 if socks_proxy.startswith("socks5://") else socks.SOCKS4
         socks_proxy = socks_proxy.split("://")[1] if "://" in socks_proxy else socks_proxy
+        
         if "@" in socks_proxy:
-            socks_username = socks_proxy.split(":")[0]
-            socks_password = socks_proxy.split(":")[1].split("@")[0]
+            if not re.match(r'^[^:@]+:.+@.+:\d+$', socks_proxy):  # One-line regex validation
+                die_failure(_("error_socks_proxy_invalid_format"))
+            credentials, host_port = socks_proxy.rsplit("@", 1)
+            socks_username, socks_password = credentials.split(":", 1)
+            socks_host, socks_port = host_port.rsplit(":", 1)
+            port = int(socks_port)
+            if not (1 <= port <= 65535):
+                die_failure(_("error_socks_proxy_invalid_port").format(socks_port))
             socks.set_default_proxy(
-                socks_version,
-                str(socks_proxy.rsplit("@")[1].rsplit(":")[0]),  # hostname
-                int(socks_proxy.rsplit(":")[-1]),  # port
-                username=socks_username,
-                password=socks_password,
+                socks_version, socks_host, port,
+                username=socks_username, password=socks_password,
             )
         else:
-            socks.set_default_proxy(
-                socks_version,
-                str(socks_proxy.rsplit(":")[0]),  # hostname
-                int(socks_proxy.rsplit(":")[1]),  # port
-            )
+            if not re.match(r'^.+:\d+$', socks_proxy):  # One-line regex validation
+                die_failure(_("error_socks_proxy_invalid_format"))
+            socks_host, socks_port = socks_proxy.rsplit(":", 1)
+            port = int(socks_port)
+            if not (1 <= port <= 65535):
+                die_failure(_("error_socks_proxy_invalid_port").format(socks_port))
+            socks.set_default_proxy(socks_version, socks_host, port)
+        
         return socks.socksocket, getaddrinfo
     else:
         return socket.socket, socket.getaddrinfo

--- a/nettacker/locale/en.yaml
+++ b/nettacker/locale/en.yaml
@@ -37,6 +37,10 @@ error_target_file: "Cannot specify the target(s), unable to open file: {0}"
 error_username: "Cannot specify the username(s), unable to open file: {0}"
 error_passwords: "Cannot specify the password(s), unable to open file: {0}"
 error_wordlist: "Cannot specify the word(s), unable to open file {0}"
+error_socks_proxy_invalid_format: |
+  Invalid SOCKS proxy format.
+  Expected format: username:password@host:port or socks5://username:password@host:port (without auth: host:port)
+error_socks_proxy_invalid_port: "Invalid SOCKS proxy port. Port must be a number between 1-65535, got: {0}"
 exclude_scan_method: choose scan method to exclude {0}
 file_write_error: file "{0}" is not writable!
 library_not_supported: library [{0}] is not support!

--- a/tests/core/test_socks_proxy.py
+++ b/tests/core/test_socks_proxy.py
@@ -1,0 +1,282 @@
+"""
+Unit tests for socks_proxy module, specifically testing set_socks_proxy() validation
+"""
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+from nettacker.core.socks_proxy import set_socks_proxy
+
+
+class TestSetSocksProxy:
+    """Test suite for set_socks_proxy function"""
+
+    def test_valid_socks5_proxy_with_auth(self):
+        """Test valid SOCKS5 proxy with authentication"""
+        # Mock the socks module before it gets imported
+        mock_socks = MagicMock()
+        mock_socks.SOCKS5 = 2
+        mock_socks.SOCKS4 = 1
+        mock_socks.socksocket = MagicMock()
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            set_socks_proxy("socks5://user:pass@proxy.example.com:1080")
+            
+            mock_socks.set_default_proxy.assert_called_once_with(
+                2,  # SOCKS5
+                "proxy.example.com",
+                1080,
+                username="user",
+                password="pass"
+            )
+
+    def test_valid_socks4_proxy_with_auth(self):
+        """Test valid SOCKS4 proxy with authentication"""
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        mock_socks.socksocket = MagicMock()
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            set_socks_proxy("user:pass@proxy.example.com:1080")
+            
+            mock_socks.set_default_proxy.assert_called_once_with(
+                1,  # SOCKS4
+                "proxy.example.com",
+                1080,
+                username="user",
+                password="pass"
+            )
+
+    def test_valid_proxy_without_auth(self):
+        """Test valid proxy without authentication"""
+        mock_socks = MagicMock()
+        mock_socks.SOCKS5 = 2
+        mock_socks.SOCKS4 = 1
+        mock_socks.socksocket = MagicMock()
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            set_socks_proxy("socks5://proxy.example.com:1080")
+            
+            mock_socks.set_default_proxy.assert_called_once_with(
+                2,  # SOCKS5
+                "proxy.example.com",
+                1080
+            )
+
+    @patch("sys.exit")
+    def test_malformed_proxy_missing_colon_in_credentials(self, mock_exit):
+        """Test that malformed proxy with @ but no : raises error (Bug #1219)"""
+        # Make sys.exit actually raise SystemExit so code stops executing
+        mock_exit.side_effect = SystemExit(1)
+        
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            with pytest.raises(SystemExit) as exc_info:
+                set_socks_proxy("user@proxy.example.com:1080")
+            
+            # Verify exit code
+            assert exc_info.value.code == 1
+
+    @patch("sys.exit")
+    def test_malformed_proxy_missing_colon_with_scheme(self, mock_exit):
+        """Test malformed proxy with scheme but missing credentials separator"""
+        mock_exit.side_effect = SystemExit(1)
+        
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            with pytest.raises(SystemExit) as exc_info:
+                set_socks_proxy("socks5://admin@server:1080")
+            
+            assert exc_info.value.code == 1
+
+    @patch("sys.exit")
+    def test_malformed_proxy_username_only(self, mock_exit):
+        """Test that proxy without host after @ raises error"""
+        mock_exit.side_effect = SystemExit(1)
+        
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            with pytest.raises(SystemExit):
+                set_socks_proxy("user:pass@")
+
+    def test_none_proxy_returns_socket(self):
+        """Test that None proxy returns normal socket"""
+        result = set_socks_proxy(None)
+        assert result[0].__name__ == 'socket'
+
+    def test_empty_string_returns_socket(self):
+        """Test that empty string returns normal socket"""
+        result = set_socks_proxy("")
+        assert result[0].__name__ == 'socket'
+
+    def test_proxy_without_port_raises_error(self):
+        """Test that proxy without port raises error"""
+        from nettacker.core.die import die_failure
+        
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            with patch('nettacker.core.socks_proxy.die_failure', side_effect=die_failure) as mock_die:
+                with pytest.raises(SystemExit):
+                    set_socks_proxy("proxy.example.com")
+                
+                # Should call die_failure with invalid format error
+                assert mock_die.called
+                error_msg = str(mock_die.call_args[0][0])
+                assert "Invalid SOCKS proxy format" in error_msg or "invalid" in error_msg.lower()
+
+    def test_proxy_with_special_chars_in_password(self):
+        """Test proxy with special characters in password"""
+        mock_socks = MagicMock()
+        mock_socks.SOCKS5 = 2
+        mock_socks.SOCKS4 = 1
+        mock_socks.socksocket = MagicMock()
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            set_socks_proxy("socks5://user:p@ss:w0rd!@proxy.example.com:1080")
+            
+            # The password should be everything between first : and @
+            mock_socks.set_default_proxy.assert_called_once_with(
+                2,
+                "proxy.example.com",
+                1080,
+                username="user",
+                password="p@ss:w0rd!"
+            )
+
+    def test_proxy_with_numeric_credentials(self):
+        """Test proxy with numeric credentials"""
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        mock_socks.socksocket = MagicMock()
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            set_socks_proxy("123:456@proxy.example.com:1080")
+            
+            mock_socks.set_default_proxy.assert_called_once_with(
+                1,
+                "proxy.example.com",
+                1080,
+                username="123",
+                password="456"
+            )
+
+    def test_proxy_without_scheme_defaults_to_socks4(self):
+        """Test that proxy without scheme defaults to SOCKS4"""
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        mock_socks.socksocket = MagicMock()
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            set_socks_proxy("user:pass@proxy.example.com:1080")
+            
+            # Should use SOCKS4 (not SOCKS5) when no scheme specified
+            assert mock_socks.set_default_proxy.call_args[0][0] == 1
+
+    def test_proxy_with_socks5_scheme(self):
+        """Test that socks5:// scheme uses SOCKS5"""
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        mock_socks.socksocket = MagicMock()
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            set_socks_proxy("socks5://user:pass@proxy.example.com:1080")
+            
+            # Should use SOCKS5
+            assert mock_socks.set_default_proxy.call_args[0][0] == 2
+
+    def test_proxy_with_invalid_port_non_numeric(self):
+        """Test that non-numeric port raises error"""
+        from nettacker.core.die import die_failure
+        
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            with patch('nettacker.core.socks_proxy.die_failure', side_effect=die_failure) as mock_die:
+                with pytest.raises(SystemExit):
+                    set_socks_proxy("proxy.example.com:abc")
+                
+                # Regex catches this as invalid format
+                assert mock_die.called
+                error_msg = str(mock_die.call_args[0][0])
+                assert "invalid" in error_msg.lower()
+
+    def test_proxy_with_invalid_port_out_of_range_low(self):
+        """Test that port < 1 raises error"""
+        from nettacker.core.die import die_failure
+        
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            with patch('nettacker.core.socks_proxy.die_failure', side_effect=die_failure) as mock_die:
+                with pytest.raises(SystemExit):
+                    set_socks_proxy("proxy.example.com:0")
+                
+                assert mock_die.called
+
+    def test_proxy_with_invalid_port_out_of_range_high(self):
+        """Test that port > 65535 raises error"""
+        from nettacker.core.die import die_failure
+        
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            with patch('nettacker.core.socks_proxy.die_failure', side_effect=die_failure) as mock_die:
+                with pytest.raises(SystemExit):
+                    set_socks_proxy("proxy.example.com:70000")
+                
+                assert mock_die.called
+
+    def test_authenticated_proxy_with_invalid_port_non_numeric(self):
+        """Test that authenticated proxy with non-numeric port raises error"""
+        from nettacker.core.die import die_failure
+        
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            with patch('nettacker.core.socks_proxy.die_failure', side_effect=die_failure) as mock_die:
+                with pytest.raises(SystemExit):
+                    set_socks_proxy("user:pass@proxy.example.com:abc")
+                
+                # Regex catches this as invalid format
+                assert mock_die.called
+                error_msg = str(mock_die.call_args[0][0])
+                assert "invalid" in error_msg.lower()
+
+    def test_authenticated_proxy_with_invalid_port_out_of_range(self):
+        """Test that authenticated proxy with port > 65535 raises error"""
+        from nettacker.core.die import die_failure
+        
+        mock_socks = MagicMock()
+        mock_socks.SOCKS4 = 1
+        mock_socks.SOCKS5 = 2
+        
+        with patch.dict('sys.modules', {'socks': mock_socks}):
+            with patch('nettacker.core.socks_proxy.die_failure', side_effect=die_failure) as mock_die:
+                with pytest.raises(SystemExit):
+                    set_socks_proxy("user:pass@proxy.example.com:99999")
+                
+                assert mock_die.called


### PR DESCRIPTION
## Description
Fixes #1219 - Adds regex validation to prevent IndexError when parsing malformed SOCKS proxy credentials.

## Root Cause
The code was attempting to split and access proxy credentials without validating the format, causing an IndexError when the input format was `user@host:port` (missing `:` separator in credentials).

## Solution
Added one-line regex validation before parsing:
- Authenticated proxies: validates format `username:password@host:port`
- Non-authenticated proxies: validates format `host:port`
- Port range validation: ensures port is between 1-65535

## Changes
- **nettacker/core/socks_proxy.py**: Added `import re` and regex validation checks
- **nettacker/locale/en.yaml**: Added error messages for invalid format and port range
- **tests/core/test_socks_proxy.py**: Added comprehensive test suite with 18 tests covering valid/invalid cases

## Test Results
All 18 tests pass:
- Valid SOCKS4/5 proxies with/without authentication
- Special characters in passwords
- Malformed inputs (missing colons, invalid ports)
- Port range validation
- Edge cases
