### PR TITLE
set APSW usage to default when using SQLite

### DIFF
--- a/nettacker/config.py
+++ b/nettacker/config.py
@@ -149,7 +149,7 @@ class DefaultSettings(ConfigBase):
     passwords = None
     passwords_list = None
     # Setting to toggle between APSW and SQLAlchemy for sqlite databases.
-    use_apsw_for_sqlite = False
+    use_apsw_for_sqlite = True
 
     ping_before_scan = False
     ports = None


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Setting APSW as the default wrapper for SQLite (removing SQLAlchemy as the current default)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [x] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
