### PR TITLE
fix: Add validation for SOCKS proxy format to prevent IndexError (#1214)

### DIFF
--- a/nettacker/core/socks_proxy.py
+++ b/nettacker/core/socks_proxy.py
@@ -21,8 +21,21 @@ def set_socks_proxy(socks_proxy):
         socks_version = socks.SOCKS5 if socks_proxy.startswith("socks5://") else socks.SOCKS4
         socks_proxy = socks_proxy.split("://")[1] if "://" in socks_proxy else socks_proxy
         if "@" in socks_proxy:
-            socks_username = socks_proxy.split(":")[0]
-            socks_password = socks_proxy.split(":")[1].split("@")[0]
+            # Extract credentials part (before @)
+            creds_part = socks_proxy.split("@")[0]
+            
+            # Validate format: must have colon separator for username:password
+            if ":" not in creds_part:
+                from nettacker.core.die import die_failure
+                die_failure(
+                    "Invalid SOCKS proxy format. "
+                    "Expected: username:password@host:port or socks5://username:password@host:port"
+                )
+            
+            # Use maxsplit=1 to handle passwords containing colons
+            parts = creds_part.split(":", 1)
+            socks_username = parts[0]
+            socks_password = parts[1]
             socks.set_default_proxy(
                 socks_version,
                 str(socks_proxy.rsplit("@")[1].rsplit(":")[0]),  # hostname

--- a/nettacker/core/socks_proxy.py
+++ b/nettacker/core/socks_proxy.py
@@ -21,8 +21,9 @@ def set_socks_proxy(socks_proxy):
         socks_version = socks.SOCKS5 if socks_proxy.startswith("socks5://") else socks.SOCKS4
         socks_proxy = socks_proxy.split("://")[1] if "://" in socks_proxy else socks_proxy
         if "@" in socks_proxy:
-            # Extract credentials part (before @)
-            creds_part = socks_proxy.split("@")[0]
+            # Use rsplit to handle passwords containing @ (e.g., user:p@ss@host:1080)
+            # rsplit("@", 1) splits from the right, so credentials = "user:p@ss", host_part = "host:1080"
+            creds_part, host_part = socks_proxy.rsplit("@", 1)
             
             # Validate format: must have colon separator for username:password
             if ":" not in creds_part:
@@ -31,6 +32,7 @@ def set_socks_proxy(socks_proxy):
                     "Invalid SOCKS proxy format. "
                     "Expected: username:password@host:port or socks5://username:password@host:port"
                 )
+                return None  # Explicit return for safety (die_failure exits, but guards against mocks)
             
             # Use maxsplit=1 to handle passwords containing colons
             parts = creds_part.split(":", 1)
@@ -38,8 +40,8 @@ def set_socks_proxy(socks_proxy):
             socks_password = parts[1]
             socks.set_default_proxy(
                 socks_version,
-                str(socks_proxy.rsplit("@")[1].rsplit(":")[0]),  # hostname
-                int(socks_proxy.rsplit(":")[-1]),  # port
+                str(host_part.rsplit(":")[0]),  # hostname from host_part
+                int(host_part.rsplit(":")[-1]),  # port from host_part
                 username=socks_username,
                 password=socks_password,
             )

--- a/tests/core/test_socks_proxy.py
+++ b/tests/core/test_socks_proxy.py
@@ -1,0 +1,101 @@
+"""Tests for socks_proxy module - specifically for issue #1214 fix."""
+import socket
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestSetSocksProxyWithoutProxy:
+    """Test set_socks_proxy when no proxy is provided."""
+
+    def test_returns_default_socket_when_none(self):
+        """Test that None proxy returns default socket objects."""
+        from nettacker.core.socks_proxy import set_socks_proxy
+        
+        sock, getaddr = set_socks_proxy(None)
+        assert sock == socket.socket
+        assert getaddr == socket.getaddrinfo
+
+    def test_returns_default_socket_when_empty_string(self):
+        """Test that empty string proxy returns default socket objects."""
+        from nettacker.core.socks_proxy import set_socks_proxy
+        
+        sock, getaddr = set_socks_proxy("")
+        assert sock == socket.socket
+        assert getaddr == socket.getaddrinfo
+
+
+class TestSetSocksProxyMalformedInput:
+    """Test set_socks_proxy with malformed input - Issue #1214."""
+
+    @patch("nettacker.core.socks_proxy.die_failure")
+    def test_malformed_at_without_colon_calls_die_failure(self, mock_die):
+        """Test that 'user@hostname' (no colon) calls die_failure."""
+        # Mock die_failure to prevent actual exit
+        mock_die.side_effect = SystemExit(1)
+        
+        from nettacker.core.socks_proxy import set_socks_proxy
+        
+        with pytest.raises(SystemExit):
+            set_socks_proxy("user@hostname:8080")
+        
+        mock_die.assert_called_once()
+        # Verify error message mentions expected format
+        call_args = str(mock_die.call_args)
+        assert "username:password@host:port" in call_args or mock_die.called
+
+    @patch("nettacker.core.socks_proxy.die_failure")
+    def test_socks5_malformed_at_without_colon(self, mock_die):
+        """Test that 'socks5://admin@server:8080' calls die_failure."""
+        mock_die.side_effect = SystemExit(1)
+        
+        from nettacker.core.socks_proxy import set_socks_proxy
+        
+        with pytest.raises(SystemExit):
+            set_socks_proxy("socks5://admin@server:8080")
+        
+        mock_die.assert_called_once()
+
+    @patch("nettacker.core.socks_proxy.die_failure") 
+    def test_socks4_malformed_at_without_colon(self, mock_die):
+        """Test that 'socks4://user@host:1080' calls die_failure."""
+        mock_die.side_effect = SystemExit(1)
+        
+        from nettacker.core.socks_proxy import set_socks_proxy
+        
+        with pytest.raises(SystemExit):
+            set_socks_proxy("socks4://user@host:1080")
+        
+        mock_die.assert_called_once()
+
+
+class TestSetSocksProxyValidInput:
+    """Test set_socks_proxy with valid formatted input."""
+
+    @patch("socks.set_default_proxy")
+    @patch("socks.socksocket")
+    def test_valid_socks5_with_credentials(self, mock_socksocket, mock_set_proxy):
+        """Test valid socks5://user:pass@host:port format."""
+        from nettacker.core.socks_proxy import set_socks_proxy
+        
+        result = set_socks_proxy("socks5://myuser:mypass@proxy.example.com:1080")
+        
+        assert mock_set_proxy.called
+        # Verify credentials were parsed correctly
+        call_args = mock_set_proxy.call_args
+        assert call_args[1]["username"] == "myuser"
+        assert call_args[1]["password"] == "mypass"
+
+    @patch("socks.set_default_proxy")
+    @patch("socks.socksocket")
+    def test_password_with_colon(self, mock_socksocket, mock_set_proxy):
+        """Test that passwords containing colons are handled correctly."""
+        from nettacker.core.socks_proxy import set_socks_proxy
+        
+        # Password "pass:word" contains a colon
+        result = set_socks_proxy("socks5://myuser:pass:word@proxy.example.com:1080")
+        
+        assert mock_set_proxy.called
+        call_args = mock_set_proxy.call_args
+        assert call_args[1]["username"] == "myuser"
+        assert call_args[1]["password"] == "pass:word"  # Full password preserved


### PR DESCRIPTION
- Add validation before accessing split results in set_socks_proxy()
- Use maxsplit=1 to handle passwords containing colons
- Call die_failure() with helpful error message when format is invalid
- Add unit tests for malformed and valid proxy inputs

Fixes: IndexError when parsing malformed SOCKS proxy string without colon separator (e.g., 'user@hostname')

<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
