### PR TITLE
Fix status field in the module wp_plugin_cve_2021_38314_vuln ( fix #1276)

### DIFF
--- a/nettacker/modules/vuln/wp_plugin_cve_2021_38314.yaml
+++ b/nettacker/modules/vuln/wp_plugin_cve_2021_38314.yaml
@@ -1,5 +1,5 @@
 info:
-  name: CVE_2021_39314_vuln
+  name: CVE_2021_38314_vuln
   author: OWASP Nettacker Team
   severity: 7
   description: Sensitive Information Leakage - The Gutenberg Template Library & Redux Framework plugin <= 4.2.11 for WordPress


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Status field and module name updated correctly in the module wp_plugin_cve_2021_38314_vuln to prevent false positives  (fix #1276 )

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [x] Bugfix (non-breaking change which fixes an issue)


<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
