### PR TITLE
Add CVE-2024-27348 vulnerability module for Apache HugeGraph

### DIFF
--- a/nettacker/modules/vuln/apache_hugegraph_cve_2024_27348.yaml
+++ b/nettacker/modules/vuln/apache_hugegraph_cve_2024_27348.yaml
@@ -38,9 +38,9 @@ payloads:
                 - 443
                 - 8080
                 - 8443
-        body:
+        data:
           type: json
-          data:
+          content:
             gremlin: 'System.getProperty("java.version")'
             bindings: "{{}}"
             language: "gremlin-groovy"


### PR DESCRIPTION
Proposed change

Added vulnerability detection module for **CVE-2024-27348** - Remote Code Execution in Apache HugeGraph-Server via Gremlin endpoint.

This module detects unauthenticated RCE vulnerability in Apache HugeGraph-Server versions 1.0.0 to 1.2.0 by testing the `/gremlin` endpoint with a Gremlin Groovy payload.

   CVE Details:
- CVE ID: CVE-2024-27348
- Severity: 9.8 CRITICAL
- Affected: Apache HugeGraph-Server 1.0.0-1.2.0
- Type: Unauthenticated Remote Code Execution

  References:
- https://nvd.nist.gov/vuln/detail/CVE-2024-27348
- https://blog.securelayer7.net/remote-code-execution-in-apache-hugegraph/
   
   Type of change

- [x] New or existing module/payload change

 Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [ ] I've run `make test`, all tests passed locally

   Note: Module has not been tested against a live vulnerable system as I don't have access to a HugeGraph lab environment. Implementation is based on CVE advisory analysis and public PoC code review.

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/