### PR TITLE
Fix the regex of wp_plugin_cve_2021_38314_vuln module ( fixes #1285 )

### DIFF
--- a/nettacker/modules/vuln/wp_plugin_cve_2021_38314.yaml
+++ b/nettacker/modules/vuln/wp_plugin_cve_2021_38314.yaml
@@ -46,7 +46,7 @@ payloads:
           condition_type: and
           conditions:
             status_code:
-              regex: 200
+              regex: "200"
               reverse: false
             headers:
               Content-Length:


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Update the regex to fix #1285 
## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
