### PR TITLE
feat(i8n): add spanish scan comparison messages

### DIFF
--- a/nettacker/locale/es.yaml
+++ b/nettacker/locale/es.yaml
@@ -143,6 +143,11 @@ nettacker_version_details:
 no_open_ports: "¡No se encontraron puertos abiertos!"
 no_user_passwords: "¡no se encontró usuario / contraseña!"
 loaded_modules: "{0} módulos cargados ..."
+compare_report_path_filename: "Ruta del archivo para el reporte de comparación"
+no_scan_to_compare: "No se encontró el ID de escaneo a comparar"
+compare_report_saved: "Resultados de comparación guardados en {0}"
+build_compare_report: "Generando reporte de comparación"
+finish_build_report: "Finalizó la generación del reporte de comparación"
 graph_module_404: "este módulo gráfico no se encuentra: {0}"
 graph_module_unavailable: este módulo de gráfico "{0}" no está disponible
 ping_before_scan: ping antes de escanear el host


### PR DESCRIPTION
feat(i18n): add scan comparison messages to spanish locale 
 This translation was done in accordance with ISO 25964-1 https://www.iso.org/standard/53657.html

Key tech decisions: 
1- report=  chosen "reporte" over " informe" .

2-no_scan_to_compare: "the scan_id to be compared not found" = " No se encontro el X ( matches spanish UI conventions) .

3-For build_compare_report ("building compare report ") and finish_build_report ("finished building compare report") : choose "generando"/"generación" over literal translation "construyendo"/"construcción" because: "construir" has strong construction industry connotations  in Spanish". "Generar" is the standard term for report or documents in technical writing ( IBM terminology , Microsoft style guide ,RAE technical context) . 

This translation is a conscious effort to contribute professionally to this great project. All translations validated by native speaker to ensure technical accuracy while maintaining natural language flow.

<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Your PR description goes here.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [x] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've run `make pre-commit`, it didn't generate any changes
- [x] I've run `make test`, all tests passed locally

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
