### PR TITLE
fix: use context managers for file operations to prevent resource leaks

### DIFF
--- a/nettacker/api/core.py
+++ b/nettacker/api/core.py
@@ -120,7 +120,8 @@ def get_file(filename):
     if not os.path.normpath(filename).startswith(str(Config.path.web_static_dir)):
         abort(404)
     try:
-        return open(filename, "rb").read()
+        with open(filename, "rb") as f:
+            return f.read()
     except ValueError:
         abort(404)
     except IOError:

--- a/nettacker/core/messages.py
+++ b/nettacker/core/messages.py
@@ -1,5 +1,4 @@
 import sys
-from io import StringIO
 
 import yaml
 
@@ -20,7 +19,8 @@ def application_language():
 
 
 def load_yaml(filename):
-    return yaml.load(StringIO(open(filename, "r").read()), Loader=yaml.FullLoader)
+    with open(filename, "r") as f:
+        return yaml.load(f, Loader=yaml.FullLoader)
 
 
 def get_languages():

--- a/nettacker/core/utils/common.py
+++ b/nettacker/core/utils/common.py
@@ -282,7 +282,8 @@ AVAILABLE_DATA_FUNCTIONS = {
 def fuzzer_function_read_file_as_array(filename):
     from nettacker.config import PathConfig
 
-    return open(PathConfig().payloads_dir / filename).read().split("\n")
+    with open(PathConfig().payloads_dir / filename) as f:
+        return f.read().split("\n")
 
 
 def apply_data_functions(data):

--- a/nettacker/lib/html_log/log_data.py
+++ b/nettacker/lib/html_log/log_data.py
@@ -1,7 +1,14 @@
 from nettacker.config import Config
 
-css_1 = open(Config.path.web_static_dir / "report/html_table.css").read()
-json_parse_js = open(Config.path.web_static_dir / "report/json_parse.js").read()
-table_end = open(Config.path.web_static_dir / "report/table_end.html").read()
-table_items = open(Config.path.web_static_dir / "report/table_items.html").read()
-table_title = open(Config.path.web_static_dir / "report/table_title.html").read()
+
+def _read_static_file(filename):
+    """Read a static file from the web static directory."""
+    with open(Config.path.web_static_dir / filename) as f:
+        return f.read()
+
+
+css_1 = _read_static_file("report/html_table.css")
+json_parse_js = _read_static_file("report/json_parse.js")
+table_end = _read_static_file("report/table_end.html")
+table_items = _read_static_file("report/table_items.html")
+table_title = _read_static_file("report/table_title.html")


### PR DESCRIPTION
## Summary
This PR fixes resource leaks caused by files being opened without context managers (`with` statement).

## Problem
Several locations used `open(filename).read()` without proper cleanup, which can cause:
- File handle exhaustion (`OSError: [Errno 24] Too many open files`)
- Non-deterministic behavior depending on garbage collection
- Reliability issues in long-running processes (API server)

## Changes

| File | Fix |
|------|-----|
| `nettacker/lib/html_log/log_data.py` | Added `_read_static_file()` helper with context manager for 5 static file reads |
| `nettacker/core/messages.py` | Wrapped YAML read with context manager, removed unused `StringIO` import |
| `nettacker/api/core.py` | Wrapped binary file read in `get_file()` with context manager |
| `nettacker/core/utils/common.py` | Wrapped payload file read in `fuzzer_function_read_file_as_array()` |

### Before & After

```python
# Before
content = open(filename).read()

# After
with open(filename) as f:
    content = f.read()
```

## Testing
- [x] All existing tests pass
- [x] Linting passes
 
## Checklist
- [x] No breaking changes
- [x] No new dependencies
- [x] Follows project coding style