### PR TITLE
fix(api): disable reloader in debug mode to prevent macOS spawn crash

### DIFF
--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -577,6 +577,7 @@ def start_api_subprocess(options):
                 host=options.api_hostname,
                 port=options.api_port,
                 debug=options.api_debug_mode,
+                use_reloader=False,
                 ssl_context=(options.api_cert, options.api_cert_key),
                 threaded=True,
             )
@@ -585,6 +586,7 @@ def start_api_subprocess(options):
                 host=options.api_hostname,
                 port=options.api_port,
                 debug=options.api_debug_mode,
+                use_reloader=False,
                 ssl_context="adhoc",
                 threaded=True,
             )


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

The API service fails to start with the `--api-debug-mode` option on MacOS with Python 3.12. 

Add `use_reloader=False` to prevent Python from spawning a child process via `multiprocessing.spawn` when debug mode is on.

The  API service starts correctly with the fix.

<img width="925" height="313" alt="nettacker_api_debug_fix" src="https://github.com/user-attachments/assets/49557bd9-d83f-455d-b6c1-6a47cc2a9575" />

Closes #1313

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I have **digitally signed** all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [x] I've run `make test`, I confirm all tests passed locally
- [ ] I've added/updated any relevant documentation in the `docs/` folder 
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [x] I have attached screenshots demonstrating my code works as intended
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
