### PR TITLE
Add multi-architecture Docker build support for ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG PYTHON_IMAGE=python:3.11.14-slim
       
 ### Build stage
-FROM ${PYTHON_IMAGE} AS builder
+FROM --platform=$BUILDPLATFORM ${PYTHON_IMAGE} AS builder
 ### Install OS dependencies and poetry package manager
 RUN apt-get update && \
     apt-get install -y gcc libssl-dev && \


### PR DESCRIPTION
## Description
This PR adds multi-platform Docker build support for linux/amd64 and linux/arm64.

The Dockerfile was updated to ensure compatibility with ARM devices such as Apple Silicon Macs and ARM-based Linux systems.

## Changes
- Added multi-architecture Docker build support
- Ensured dependencies build correctly for ARM64
- Tested Docker build using docker buildx

## Test
Successfully built image using:
docker buildx build --platform linux/amd64,linux/arm64 -t nettacker-test .

<img width="1006" height="778" alt="image" src="https://github.com/user-attachments/assets/94dee2f9-eaf7-47b6-894a-518288610d56" />

Both architectures completed successfully.

Fixes  #1350