### PR TITLE
fix(api): Display correct cert error message

### DIFF
--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -2,8 +2,8 @@ import csv
 import json
 import multiprocessing
 import os
-import ssl
 import random
+import ssl
 import string
 import sys
 import time
@@ -592,9 +592,9 @@ def start_api_subprocess(options):
                 ssl_context="adhoc",
                 threaded=True,
             )
-    except (ssl.SSLError, ValueError) as se:
+    except (ssl.SSLError, ValueError):
         die_failure(_("load_ssl_fail"))
-    except FileNotFoundError as fe:
+    except FileNotFoundError:
         die_failure(_("file_not_found"))
     except Exception as e:
         die_failure(str(e))
@@ -622,5 +622,5 @@ def start_api_server(options):
             break
 
     if p.exitcode != 0:
-            # The child stopped. Exit the parent so it doesn't print "Cannot specify targets"
-            sys.exit(1)
+        # The child stopped. Exit the parent so it doesn't print "Cannot specify targets"
+        sys.exit(1)

--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -2,8 +2,10 @@ import csv
 import json
 import multiprocessing
 import os
+import ssl
 import random
 import string
+import sys
 import time
 from threading import Thread
 from types import SimpleNamespace
@@ -590,6 +592,10 @@ def start_api_subprocess(options):
                 ssl_context="adhoc",
                 threaded=True,
             )
+    except (ssl.SSLError, ValueError) as se:
+        die_failure(_("load_ssl_fail"))
+    except FileNotFoundError as fe:
+        die_failure(_("file_not_found"))
     except Exception as e:
         die_failure(str(e))
 
@@ -614,3 +620,7 @@ def start_api_server(options):
             for process in multiprocessing.active_children():
                 process.terminate()
             break
+
+    if p.exitcode != 0:
+            # The child stopped. Exit the parent so it doesn't print "Cannot specify targets"
+            sys.exit(1)

--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -592,7 +592,7 @@ def start_api_subprocess(options):
                 ssl_context="adhoc",
                 threaded=True,
             )
-    except (ssl.SSLError, ValueError):
+    except ssl.SSLError:
         die_failure(_("load_ssl_fail"))
     except FileNotFoundError:
         die_failure(_("file_not_found"))

--- a/nettacker/locale/en.yaml
+++ b/nettacker/locale/en.yaml
@@ -143,3 +143,5 @@ read_report_fail: Failed to read report file {0}
 search_results_end: No more search results
 database_error: Database error!
 error_exclude_all: "Cannot exclude all modules. Please specify individual module names to exclude using -x."
+file_not_found: "File not found"
+load_ssl_fail: "Failed to load SSL configuration. Please check your --api-cert and --api-cert-key files."


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

- Enhanced SSL Error Trapping: Added a try-except block to the API engine to catch `ssl.SSLError` and `ValueError` during the Flask server initialization.
- New Localization Keys: Added two new message keys to `en.yaml` to provide user-friendly feedback when certificate loading fails, replacing generic tracebacks with actionable error messages.
- Implemented an explicit `sys.exit(1)` within `start_api_server`. If the child process terminates with a non-zero exit code (e.g., due to an SSL PEM lib error), the parent process now calls `sys.exit(1)` immediately. This prevents the misleading `Cannot specify the target(s)` error.

With invalid cert files,
```
poetry run nettacker --start-api --api-host 127.0.0.1 --api-port 8080 --api-debug-mode --api-cert /etc/hosts --api-cert-key /etc/hosts
```

<img width="1009" height="314" alt="invalid_cert_file_fx" src="https://github.com/user-attachments/assets/fa5201bb-5905-44cc-a55b-fdb8e6794708" />

<br/><br/>

With wrong cert paths,

```
poetry run nettacker --start-api --api-host 127.0.0.1 --api-port 8080 --api-debug-mode --api-cert /etc/xxx --api-cert-key /etc/xxx
```

<img width="1011" height="307" alt="invalid_cert_file_not_found" src="https://github.com/user-attachments/assets/5913fca9-ca07-451a-bfc7-b01ec9f9a88a" />

Closes #1354 

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I have **digitally signed** all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [x] I've run `make test`, I confirm all tests passed locally
- [ ] I've added/updated any relevant documentation in the `docs/` folder 
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [x] I have attached screenshots demonstrating my code works as intended
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
