### PR TITLE
Add slow_endpoint_scan module to detect slow HTTP endpoints

### DIFF
--- a/nettacker/modules/scan/slow_endpoint.yaml
+++ b/nettacker/modules/scan/slow_endpoint.yaml
@@ -24,7 +24,7 @@ payloads:
 
         url:
           nettacker_fuzzer:
-            input_format: "{{schema}}://{target}:{{ports}}/{{urls}}"
+            input_format: "{{schema}}://{{target}}:{{ports}}/{{urls}}"
             prefix: ""
             suffix: ""
             interceptors: ""


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR introduces a new module **`slow_endpoint_scan`** for detecting slow HTTP endpoints.

The module identifies URLs that take more than **3 seconds** to respond. Slow responses may indicate inefficient backend processing, blocking operations, or endpoints vulnerable to resource exhaustion attacks.

The module works by using Nettacker's `responsetime` condition to detect delayed responses and logs the affected endpoint URLs.

Tested locally using a Flask-based lab environment with intentionally delayed endpoints to verify detection.


## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [x ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [ ] I have **digitally signed** all my commits in this PR
- [ ] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [ ] I've run `make test`, I confirm all tests passed locally
- [ ] I've added/updated any relevant documentation in the `docs/` folder 
- [ ] I've linked this PR with an open issue
- [x ] I've tested and verified that my code works as intended and resolves the issue as described
- [xI have attached screenshots demonstrating my code works as intended
- [x ] I've checked all other open PRs to avoid submitting duplicate work
- [x ] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision
<img width="1835" height="1006" alt="Screenshot from 2026-03-09 07-35-14" src="https://github.com/user-attachments/assets/0899b8a2-aafd-489e-b916-bc7fb40a7304" />


<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/
