### PR TITLE
l10n: add comparison functionality translations to Dutch locale

### DIFF
--- a/nettacker/locale/nl.yaml
+++ b/nettacker/locale/nl.yaml
@@ -252,3 +252,8 @@ no_response: kan geen reactie krijgen van het doelwit
 category_framework: "categorie: {0}, frameworks: {1} gevonden!"
 nothing_found: niets gevonden op {0} in {1}!
 no_auth: "Geen authenticatie gevonden op {0}: {1}"
+compare_report_path_filename: "het bestandspad om het compare_scan rapport op te slaan"
+no_scan_to_compare: "de scan_id om te vergelijken is niet gevonden"
+compare_report_saved: "vergelijkingsresultaten opgeslagen in {0}"
+build_compare_report: "vergelijkingsrapport wordt opgebouwd"
+finish_build_report: "vergelijkingsrapport voltooid"


### PR DESCRIPTION
## What this PR does
Added missing Dutch (nl) locale translation keys for 
comparison functionality messages in nettacker/locale/nl.yaml.

## Keys added
- compare_report_path
- compare_scan_id_not_found  
- compare_report_saved
- compare_report_building/completion

## Why
These keys were missing from the Dutch locale file, causing 
untranslated strings to appear when using comparison features 
with the nl locale setting.

## Type of change
- [x] Documentation/localization improvement