### PR TITLE
remove exec() from responsetime condition evaluator

### DIFF
--- a/nettacker/core/lib/http.py
+++ b/nettacker/core/lib/http.py
@@ -27,8 +27,8 @@ _RESPONSETIME_OPS = {
     "!=": operator.ne,
     ">=": operator.ge,
     "<=": operator.le,
-    ">":  operator.gt,
-    "<":  operator.lt,
+    ">": operator.gt,
+    "<": operator.lt,
 }
 
 


### PR DESCRIPTION
This PR removes the use of exec() in
nettacker/core/lib/http.py → response_conditions_matched()
when evaluating the responsetime condition.

The previous implementation constructed a Python expression using
values taken directly from module YAML and executed it with exec(),
which allows arbitrary code execution if a crafted condition string is provided.

Example of previous pattern:

exec(
    f"matched = response['responsetime'] "
    f"{conditions['responsetime'].split()[0]} "
    f"{conditions['responsetime'].split()[1]}"
)

Since the operator comes from YAML, this is unsafe.

Changes

Replace exec() with explicit operator dispatch

Allow only valid comparison operators:

== != > < >= <=

Preserve existing behaviour for valid modules

No API / module format changes

New logic uses a safe mapping:

ops = {
    '==': float.__eq__,
    '!=': float.__ne__,
    '>=': float.__ge__,
    '<=': float.__le__,
    '>':  float.__gt__,
    '<':  float.__lt__,
}  
fixes #1408 