### PR TITLE
fix: remove exec() from response_conditions_matched, use operator map instead

### DIFF
--- a/nettacker/core/lib/http.py
+++ b/nettacker/core/lib/http.py
@@ -73,21 +73,20 @@ def response_conditions_matched(sub_step, response):
                 except TypeError:
                     condition_results["headers"][header] = []
         if condition == "responsetime":
-            if len(conditions[condition].split()) == 2 and conditions[condition].split()[0] in [
-                "==",
-                "!=",
-                ">=",
-                "<=",
-                ">",
-                "<",
-            ]:
-                exec(
-                    "condition_results['responsetime'] = response['responsetime'] if ("
-                    + "response['responsetime'] {0} float(conditions['responsetime'].split()[-1])".format(
-                        conditions["responsetime"].split()[0]
-                    )
-                    + ") else []"
-                )
+            ops = {
+                "==": float.__eq__,
+                "!=": float.__ne__,
+                ">=": float.__ge__,
+                "<=": float.__le__,
+                ">": float.__gt__,
+                "<": float.__lt__,
+            }
+            parts = conditions[condition].split()
+            if len(parts) == 2 and parts[0] in ops:
+                op = ops[parts[0]]
+                threshold = float(parts[1])
+                t = response["responsetime"]
+                condition_results["responsetime"] = t if op(t, threshold) else []
             else:
                 condition_results["responsetime"] = []
     if condition_type.lower() == "or":


### PR DESCRIPTION
Fixes #1408

  ## What was wrong

  The `responsetime` condition check in `response_conditions_matched()`
  was using `exec()` to evaluate comparison operators pulled directly
  from YAML module configs. A crafted module file with something like
  `">= 0 or __import__('os').system('id')"` could get arbitrary Python
  executed during a scan.

  ## What I changed

  Replaced the `exec()` block with a simple operator dispatch dictionary
  that maps each valid operator string (`==`, `!=`, `>=`, `<=`, `>`, `<`)
  to the corresponding `float` method. The behavior and supported operators
  are identical — just no more dynamic code execution.

  ## Files changed

  - `nettacker/core/lib/http.py` — replaced lines 76-91