### PR TITLE
Fix: Render HTML scan reports inline instead of downloading

### DIFF
--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -393,17 +393,26 @@ def get_result_content():
     safe_filename = secure_filename(os.path.basename(str(filename)))
 
     # Render HTML reports inline in the browser instead of forcing a download.
-    # Non-HTML files continue to be served as attachment downloads.
+    # This allows users to view scan results directly while maintaining security.
+    # Non-HTML files (.json, .csv, .txt) continue to be served as attachment downloads.
     if file_extension in (".html", ".htm"):
         response = Response(
             file_content,
             mimetype="text/html",
-            headers={"Content-Disposition": "inline;filename=" + safe_filename},
+            headers={"Content-Disposition": f"inline; filename={safe_filename}"},
         )
-        # Restrict inline HTML content to mitigate XSS risks (no scripts, no external resources)
-        response.headers[
-            "Content-Security-Policy"
-        ] = "default-src 'self'; script-src 'none'; style-src 'self' 'unsafe-inline'"
+        # Security: Strict Content-Security-Policy to mitigate XSS risks.
+        # We disable all script execution (script-src 'none') and restrict other resources
+        # to ensure that user-generated HTML reports cannot execute malicious code.
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'none'; "
+            "script-src 'none'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data:; "
+            "font-src 'self'; "
+            "connect-src 'self'; "
+            "frame-ancestors 'none';"
+        )
         return response
 
     return Response(

--- a/tests/api/test_engine.py
+++ b/tests/api/test_engine.py
@@ -100,7 +100,7 @@ def _stub_nettacker_modules():
     # Expose it on the fixture's module so tests can reference it.
     _stub_nettacker_modules.app = _app  # type: ignore[attr-defined]
 
-    yield
+    yield _stub_nettacker_modules
 
     # Restore sys.modules to its original state.
     for name, original in originals.items():
@@ -145,7 +145,9 @@ def test_html_report_rendered_inline(mock_get_scan_result, mock_api_key, client)
     assert "attachment" not in cd, "attachment must NOT appear for HTML reports"
     assert "report.html" in cd
     csp = response.headers.get("Content-Security-Policy", "")
+    assert "default-src 'none'" in csp
     assert "script-src 'none'" in csp, f"Expected CSP to block scripts, got: {csp}"
+    assert "frame-ancestors 'none'" in csp
 
 
 @patch("nettacker.api.engine.api_key_is_valid")
@@ -163,7 +165,9 @@ def test_htm_report_rendered_inline(mock_get_scan_result, mock_api_key, client):
     assert "attachment" not in cd
     # .htm must carry the same restrictive CSP as .html (security parity)
     csp = response.headers.get("Content-Security-Policy", "")
+    assert "default-src 'none'" in csp
     assert "script-src 'none'" in csp, f"Expected CSP to block scripts for .htm, got: {csp}"
+    assert "frame-ancestors 'none'" in csp
 
 
 @patch("nettacker.api.engine.api_key_is_valid")


### PR DESCRIPTION
## Summary

Fixes #1316

Currently, clicking a scan result link in the WebUI (e.g. `/results/get?id=2`) triggers an automatic file download of the HTML report. This PR changes that so HTML reports open and render directly in the browser.

## Root Cause

[get_result_content()](cci:1://file:///c:/Users/User/Desktop/Nettacker/nettacker/api/engine.py:372:0-411:5) in [nettacker/api/engine.py](cci:7://file:///c:/Users/User/Desktop/Nettacker/nettacker/api/engine.py:0:0-0:0) was unconditionally setting `Content-Disposition: attachment` for all file types, forcing the browser to download instead of render.

## Changes

**Modified:** [nettacker/api/engine.py](cci:7://file:///c:/Users/User/Desktop/Nettacker/nettacker/api/engine.py:0:0-0:0)

- For `.html` / `.htm` files:
  - `Content-Disposition` changed from [attachment](cci:1://file:///c:/Users/User/Desktop/Nettacker/tests/api/test_engine.py:155:0-167:29) to [inline](cci:1://file:///c:/Users/User/Desktop/Nettacker/tests/api/test_engine.py:121:0-133:33)
  - `mimetype` set explicitly to `text/html`
  - Added `Content-Security-Policy: default-src 'self'; script-src 'none'; style-src 'self' 'unsafe-inline'` to mitigate XSS risk
- For all other file types (`.json`, [.txt](cci:7://file:///c:/Users/User/Desktop/Nettacker/nettacker/logo.txt:0:0-0:0), `.csv`): **behaviour unchanged** — still downloaded as attachments

**Added:** [tests/api/test_engine.py](cci:7://file:///c:/Users/User/Desktop/Nettacker/tests/api/test_engine.py:0:0-0:0)

New unit tests for the `/results/get` endpoint:
- [test_html_report_rendered_inline](cci:1://file:///c:/Users/User/Desktop/Nettacker/tests/api/test_engine.py:103:0-118:83) — HTML uses [inline](cci:1://file:///c:/Users/User/Desktop/Nettacker/tests/api/test_engine.py:121:0-133:33), `text/html`, and CSP blocks scripts
- [test_htm_report_rendered_inline](cci:1://file:///c:/Users/User/Desktop/Nettacker/tests/api/test_engine.py:121:0-133:33) — `.htm` behaves the same as `.html`
- [test_json_report_downloaded_as_attachment](cci:1://file:///c:/Users/User/Desktop/Nettacker/tests/api/test_engine.py:136:0-152:41) — JSON still downloads
- [test_txt_report_downloaded_as_attachment](cci:1://file:///c:/Users/User/Desktop/Nettacker/tests/api/test_engine.py:155:0-167:29) — TXT still downloads

## Security Consideration

Rendering HTML inline introduces potential XSS risk if report content is adversarial. This is mitigated by setting `script-src 'none'` in the Content-Security-Policy, which blocks all script execution. Nettacker HTML reports are static styled documents that do not require JavaScript.

## Testing

- All 4 new unit tests pass
- `ruff check` linting passes cleanly
- Non-HTML types verified to still download via tests
