### PR TITLE
Standardize CLI error messages for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,28 @@ OWASP Nettacker
 ![2018-01-19_0-45-07](https://user-images.githubusercontent.com/7676267/35123376-283d5a3e-fcb7-11e7-9b1c-92b78ed4fecc.gif)
 
 OWASP Nettacker is an open-source, Python-based automated penetration testing and information-gathering framework designed to help cyber security professionals and ethical hackers perform reconnaissance, vulnerability assessments, and network security audits efficiently. Nettacker automates tasks like port scanning, service detection, subdomain enumeration, network mapping, vulnerability scanning, credential brute-force testing making it a powerful tool for identifying weaknesses in networks, web applications, IoT devices and APIs.
- ### ⚠️ Windows Support
+ ## ⚠️ Windows Support
 
+OWASP Nettacker does not support native Windows execution due to compatibility issues with certain Python dependencies and networking libraries.
+
+### Recommended Solutions
+
+#### 1. Docker (Recommended)
+Docker provides the easiest cross-platform solution.
+
+- Install Docker Desktop: https://docs.docker.com/desktop/install/windows-install/
+- Follow Nettacker Docker usage instructions in this repository
+
+#### 2. Windows Subsystem for Linux (WSL)
+- Install WSL: https://learn.microsoft.com/en-us/windows/wsl/install
+- Install Ubuntu
+- Run Nettacker inside WSL environment
+
+#### 3. Kali Linux / Virtual Machine
+- Use Kali Linux or any Linux VM
+- Install dependencies and run Nettacker normally
+
+These methods ensure full compatibility and avoid runtime errors.
 OWASP Nettacker does not support native Windows execution.
 
 ### Recommended Solutions:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,28 @@ This ensures compatibility and avoids runtime errors.
 - **Built-in database & drift detection** - Stores past scans in the database for easy search and comparison with current results: useful to detect new hosts, open ports, or vulnerabilities in CI/CD pipelines.
 - **CLI, REST API & Web UI** - Offers both programmatic integration and a user-friendly web interface for defining scans and viewing results.
 - **Evasion techniques** - Enables configurable delays, proxy support, and randomized user-agents to reduce detection by firewalls or IDS systems.
-- **Flexible targets** - Accepts single IPv4s, IP ranges, CIDR blocks, domain names, and full HTTP/HTTPS URLs. Targets can be mixed in a single command or loaded from a file using the `-l/--targets-list` flag. 
+## ⚠️ Windows Support
+
+OWASP Nettacker does not support native Windows execution due to compatibility issues with certain Python dependencies and networking libraries.
+
+### Recommended Solutions
+
+#### 1. Docker (Recommended)
+Docker provides the easiest cross-platform solution.
+
+- Install Docker Desktop: https://docs.docker.com/desktop/install/windows-install/
+- Follow Nettacker Docker usage instructions in this repository
+
+#### 2. Windows Subsystem for Linux (WSL)
+- Install WSL: https://learn.microsoft.com/en-us/windows/wsl/install
+- Install Ubuntu
+- Run Nettacker inside WSL environment
+
+#### 3. Kali Linux / Virtual Machine
+- Use Kali Linux or any Linux VM
+- Install dependencies and run Nettacker normally
+
+These methods ensure full compatibility and avoid runtime errors.- **Flexible targets** - Accepts single IPv4s, IP ranges, CIDR blocks, domain names, and full HTTP/HTTPS URLs. Targets can be mixed in a single command or loaded from a file using the `-l/--targets-list` flag. 
 
 ### Use Cases
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ OWASP Nettacker
 ![2018-01-19_0-45-07](https://user-images.githubusercontent.com/7676267/35123376-283d5a3e-fcb7-11e7-9b1c-92b78ed4fecc.gif)
 
 OWASP Nettacker is an open-source, Python-based automated penetration testing and information-gathering framework designed to help cyber security professionals and ethical hackers perform reconnaissance, vulnerability assessments, and network security audits efficiently. Nettacker automates tasks like port scanning, service detection, subdomain enumeration, network mapping, vulnerability scanning, credential brute-force testing making it a powerful tool for identifying weaknesses in networks, web applications, IoT devices and APIs.
+ ### ⚠️ Windows Support
+
+OWASP Nettacker does not support native Windows execution.
+
+### Recommended Solutions:
+
+**1. Windows Subsystem for Linux (WSL)**
+- Install WSL
+- Install Ubuntu
+- Run Nettacker inside Linux environment
+
+**2. Kali Linux / Virtual Machine**
+- Use Kali Linux or any Linux VM
+
+This ensures compatibility and avoids runtime errors.
 
 ### Key Features
 

--- a/nettacker/locale/en.yaml
+++ b/nettacker/locale/en.yaml
@@ -34,15 +34,15 @@ choose_scan_method: choose modules {0} to see full list use --show-all-modules
 cannot_run_api_server: You can't run API Server through itself!
 error_target: "Error: No target specified. Use -i <IP> or --target <host> to define scan target."
 error_target_file: "Error: No target specified. Unable to open file: {0}"
-error_username: "Cannot specify the username(s), unable to open file: {0}"
-error_passwords: "Cannot specify the password(s), unable to open file: {0}"
-error_wordlist: "Cannot specify the word(s), unable to open file {0}"
+error_username: "Error: No username specified. Unable to open file: {0}"
+error_passwords: "Error: No password specified. Unable to open file: {0}"
+error_wordlist: "Error: No wordlist specified. Unable to open file: {0}"
 exclude_scan_method: choose scan method to exclude {0}
 file_write_error: file "{0}" is not writable!
 library_not_supported: library [{0}] is not support!
 removing_old_db_records: Removing old database record for selected targets and modules.
 regrouping_targets: regrouping targets based on hardware resources!
-finish_build_graph: finish building graph!
+nish_build_graph: finish building graph!
 finished_parallel_module_scan: process-{0}|{1}|{2}| finished module thread number {3} from {4}
 graph_message: "This graph created by OWASP Nettacker. Graph contains all modules activities, network map and
 sensitive information, Please don't share this file with anyone if it's not reliable."

--- a/nettacker/locale/en.yaml
+++ b/nettacker/locale/en.yaml
@@ -32,8 +32,8 @@ finished_module: finished module {0} towards the target {1} | module thread numb
 modules_extra_args_help: add extra args to pass to modules (e.g. --modules-extra-args "x_api_key=123&xyz_passwd=abc"
 choose_scan_method: choose modules {0} to see full list use --show-all-modules
 cannot_run_api_server: You can't run API Server through itself!
-error_target: Cannot specify the target(s)
-error_target_file: "Cannot specify the target(s), unable to open file: {0}"
+error_target: "Error: No target specified. Use -i <IP> or --target <host> to define scan target."
+error_target_file: "Error: No target specified. Unable to open file: {0}"
 error_username: "Cannot specify the username(s), unable to open file: {0}"
 error_passwords: "Cannot specify the password(s), unable to open file: {0}"
 error_wordlist: "Cannot specify the word(s), unable to open file {0}"


### PR DESCRIPTION
## Proposed Change

Standardized CLI error messages for username, password, and wordlist inputs to improve consistency and clarity.

## Why this change is needed

Some error messages were inconsistent and unclear compared to recently improved target error messages.

## What is added

- Consistent error format starting with "Error:"
- Clear indication of missing inputs
- Improved readability and usability

## Type of change

- [x] Other improvement (usability / UX)

## Checklist

- [x] I have followed the contributing guidelines
- [x] I have tested the change locally