### PR TITLE
Improve error messages for target validation

### DIFF
--- a/nettacker/locale/en.yaml
+++ b/nettacker/locale/en.yaml
@@ -32,8 +32,8 @@ finished_module: finished module {0} towards the target {1} | module thread numb
 modules_extra_args_help: add extra args to pass to modules (e.g. --modules-extra-args "x_api_key=123&xyz_passwd=abc"
 choose_scan_method: choose modules {0} to see full list use --show-all-modules
 cannot_run_api_server: You can't run API Server through itself!
-error_target: Cannot specify the target(s)
-error_target_file: "Cannot specify the target(s), unable to open file: {0}"
+error_target: No target specified. Use -t or --targets to define scan target(s).
+error_target_file: "Target file error: cannot open file: {0}"
 error_username: "Cannot specify the username(s), unable to open file: {0}"
 error_passwords: "Cannot specify the password(s), unable to open file: {0}"
 error_wordlist: "Cannot specify the word(s), unable to open file {0}"

--- a/nettacker/locale/en.yaml
+++ b/nettacker/locale/en.yaml
@@ -32,7 +32,7 @@ finished_module: finished module {0} towards the target {1} | module thread numb
 modules_extra_args_help: add extra args to pass to modules (e.g. --modules-extra-args "x_api_key=123&xyz_passwd=abc"
 choose_scan_method: choose modules {0} to see full list use --show-all-modules
 cannot_run_api_server: You can't run API Server through itself!
-error_target: No target specified. Use -t or --targets to define scan target(s).
+error_target: No target specified. Use -i or --targets to define scan target(s).
 error_target_file: "Target file error: cannot open file: {0}"
 error_username: "Cannot specify the username(s), unable to open file: {0}"
 error_passwords: "Cannot specify the password(s), unable to open file: {0}"


### PR DESCRIPTION
## Proposed change

This PR improves localization error messages in `nettacker/locale/en.yaml` for better clarity and usability.

Changes include:
- Improved `error_target` message to clearly instruct users to use `-t` or `--targets`
- Improved `error_target_file` message to provide a clearer file-related error description

These changes make CLI error messages more user-friendly and easier to understand for end users.

## Type of change

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [x] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

- [x] I've followed the contributing guidelines
- [ ] I have **digitally signed** all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [x] I've run `make test`, I confirm all tests passed locally
- [ ] I've added/updated any relevant documentation in the `docs/` folder
- [ ] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [x] I have attached screenshots demonstrating my code works as intended
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

 Thanks for contributing to OWASP Nettacker!
<img width="1212" height="475" alt="image" src="https://github.com/user-attachments/assets/81dc610b-b6f8-40ce-8794-7c2b51eb79ef" />

