### PR TITLE
docs: add beginner-friendly command examples to Usage.md

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -368,8 +368,27 @@ python nettacker.py -i nettackerwebsiteblabla.com,owasp.org,192.168.1.1 -s -r -m
 
 - Note: If host scan finishes, and couldn't get any result nothing will be listed in the output file unless you change the verbosity mode to a value from 1 to 5.
 
+## Additional Examples for Beginners
+
+### Basic Scan
 ```
-python nettacker.py -i 192.168.1.1/24 -m all -t 10 -M 35 -g 20-100 -o file.txt -u root,user -P passwords.txt -v 1
+python nettacker.py -i example.com -m port_scan
+```
+### Scan Multiple Targets from File
+```
+python nettacker.py -l targets.txt -m all
+```
+### Save Output to JSON
+```
+python nettacker.py -i example.com -o result.json
+```
+### Brute Force Example
+```
+python nettacker.py -i example.com -m ssh_brute -U users.txt -P passwords.txt
+```
+### Scan Specific Port Range
+```
+python nettacker.py -i example.com -m port_scan -g 20-100
 ```
 
 - Use `*` pattern for selecting modules

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -371,23 +371,23 @@ python nettacker.py -i nettackerwebsiteblabla.com,owasp.org,192.168.1.1 -s -r -m
 ## Additional Examples for Beginners
 
 ### Basic Scan
-```
+```bash
 python nettacker.py -i example.com -m port_scan
 ```
 ### Scan Multiple Targets from File
-```
+```bash
 python nettacker.py -l targets.txt -m all
 ```
 ### Save Output to JSON
-```
+```bash
 python nettacker.py -i example.com -o result.json
 ```
 ### Brute Force Example
-```
+```bash
 python nettacker.py -i example.com -m ssh_brute -U users.txt -P passwords.txt
 ```
 ### Scan Specific Port Range
-```
+```bash
 python nettacker.py -i example.com -m port_scan -g 20-100
 ```
 


### PR DESCRIPTION
## Proposed change

This PR adds structured and beginner-friendly command examples to `docs/Usage.md`.

The goal is to help new users understand how to use Nettacker with clear, practical examples.

Added examples include:
- Basic scan of a single target
- Scanning multiple targets from a file
- Saving scan results to JSON format
- Using brute-force modules (ssh_brute)
- Scanning specific port ranges

This improves usability and reduces confusion for first-time users.

Fixes #740


## Type of change

- [x] Documentation/localization improvement


## Checklist

- [x] I've followed the contributing guidelines
- [x] I've digitally signed all my commits in this PR
- [ ] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [ ] I've run `make test` and I confirm all tests passed locally
- [x] I've added/updated relevant documentation in the `docs/` folder
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my changes work as intended
- [ ] I've attached screenshots demonstrating that my changes work (not applicable)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments are not direct unreviewed AI output
- [x] I confirm that I am the sole responsible author for this contribution