### PR TITLE
fix(docker): include LICENSE in runtime image for Apache-2.0 attribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ ENV PATH=/usr/src/owaspnettacker/.venv/bin:$PATH
 RUN pip install --no-deps --no-cache-dir nettacker-*.whl && \
     rm -f nettacker-*.whl
 
+### Preserve Apache-2.0 license text in the final image for downstream attribution
+COPY LICENSE ./
+
 ### We now have Nettacker installed in the virtualenv with 'nettacker' command which is the new entrypoint
 ENV docker_env=true
 ENTRYPOINT [ "nettacker" ]


### PR DESCRIPTION
## Proposed change

Adds `COPY LICENSE ./` to the runtime stage of the Dockerfile so the Apache-2.0 license text ends up at `/usr/src/owaspnettacker/LICENSE` in every built image.

Closes #1559

One line plus a one-line comment. No runtime behavior change. Image grows by about 11 KB.

Verified on the built image:

```
$ docker run --rm --entrypoint sh nettacker:test -c 'ls -la /usr/src/owaspnettacker/LICENSE'
-rw-r--r-- 1 root root 11357 ... LICENSE
```

Placed in the runtime stage rather than the builder, so the wheel build and the builder-stage cache layers are untouched.

> Local checks: `make pre-commit` clean. `make test` shows 2 pre-existing failures on Python 3.12 (`test_socket::test_create_tcp_socket`, `test_ssl::test_create_tcp_socket`) caused by `ssl.wrap_socket` being removed from the 3.12 stdlib. The same two failures reproduce on plain `master`, so they are unrelated to this change. CI is green.

## Type of change

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [x] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've **digitally signed** all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [ ] I've run `make test` and I confirm all tests passed locally
- [ ] I've added/updated any relevant documentation in the `docs/` folder
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [ ] I've attached screenshots demonstrating that my code works as intended (if applicable)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [ ] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines
