### PR TITLE
Fix yaml.load deprecation and SQL injection vulnerabilities

### DIFF
--- a/nettacker/core/messages.py
+++ b/nettacker/core/messages.py
@@ -1,5 +1,4 @@
 import sys
-from io import StringIO
 
 import yaml
 
@@ -20,7 +19,7 @@ def application_language():
 
 
 def load_yaml(filename):
-    return yaml.load(StringIO(open(filename, "r").read()), Loader=yaml.FullLoader)
+    return yaml.safe_load(open(filename, "r").read())
 
 
 def get_languages():

--- a/nettacker/database/db.py
+++ b/nettacker/database/db.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 
 try:
@@ -59,9 +60,21 @@ def create_connection():
             connection.setbusytimeout(int(config.settings.timeout) * 100)
             cursor = connection.cursor()
 
+            # Validate PRAGMA values to prevent injection
+            valid_journal_modes = {"DELETE", "TRUNCATE", "PERSIST", "MEMORY", "WAL", "OFF"}
+            valid_sync_modes = {"OFF", "NORMAL", "FULL", "EXTRA"}
+
+            journal_mode = Config.db.journal_mode.upper()
+            sync_mode = Config.db.synchronous_mode.upper()
+
+            if journal_mode not in valid_journal_modes:
+                raise ValueError(f"Invalid journal_mode: {Config.db.journal_mode}")
+            if sync_mode not in valid_sync_modes:
+                raise ValueError(f"Invalid synchronous_mode: {Config.db.synchronous_mode}")
+
             # Performance enhancing configurations. Put WAL cause that helps with concurrency.
-            cursor.execute(f"PRAGMA journal_mode={Config.db.journal_mode}")
-            cursor.execute(f"PRAGMA synchronous={Config.db.synchronous_mode}")
+            cursor.execute(f"PRAGMA journal_mode={journal_mode}")
+            cursor.execute(f"PRAGMA synchronous={sync_mode}")
 
             return connection, cursor
         except Exception as e:

--- a/nettacker/database/mysql.py
+++ b/nettacker/database/mysql.py
@@ -1,7 +1,19 @@
+import re
+
 from sqlalchemy import create_engine, text
 
 from nettacker.config import Config
 from nettacker.database.models import Base
+
+
+def _validate_identifier(name):
+    """
+    Validate a database identifier to prevent SQL injection.
+    Only alphanumeric characters and underscores are allowed.
+    """
+    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", name):
+        raise ValueError(f"Invalid database identifier: {name}")
+    return name
 
 
 def mysql_create_database():
@@ -20,7 +32,7 @@ def mysql_create_database():
             existing_databases = [d[0] for d in existing_databases]
 
             if Config.db.name not in existing_databases:
-                conn.execute(text("CREATE DATABASE {0} ".format(Config.db.name)))
+                conn.execute(text(f"CREATE DATABASE {_validate_identifier(Config.db.name)}"))
     except Exception as e:
         print(e)
 

--- a/nettacker/database/postgresql.py
+++ b/nettacker/database/postgresql.py
@@ -1,8 +1,20 @@
+import re
+
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError
 
 from nettacker.config import Config
 from nettacker.database.models import Base
+
+
+def _validate_identifier(name):
+    """
+    Validate a database identifier to prevent SQL injection.
+    Only alphanumeric characters and underscores are allowed.
+    """
+    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", name):
+        raise ValueError(f"Invalid database identifier: {name}")
+    return name
 
 
 def postgres_create_database():
@@ -26,7 +38,7 @@ def postgres_create_database():
         )
         conn = engine.connect()
         conn = conn.execution_options(isolation_level="AUTOCOMMIT")
-        conn.execute(text(f"CREATE DATABASE {Config.db.name}"))
+        conn.execute(text(f"CREATE DATABASE {_validate_identifier(Config.db.name)}"))
         conn.close()
         engine = create_engine(
             "postgresql+psycopg2://{username}:{password}@{host}:{port}/{name}".format(


### PR DESCRIPTION
## Security Fixes

Found a couple of security issues while doing a security audit for a client who uses Nettacker in their pentest workflow. Figured I should upstream the fixes.

### 1. yaml.load() with FullLoader (messages.py)

The `yaml.load()` call was using `FullLoader` instead of `SafeLoader`. While FullLoader is better than the default `Loader`, it can still be exploited through YAML deserialization attacks. Switched to `yaml.safe_load()` which is the recommended approach per PyYAML docs and also removed the unnecessary `StringIO` wrapper.

Ref: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

### 2. SQL Injection in database creation (mysql.py, postgresql.py)

The `CREATE DATABASE` statements in both MySQL and PostgreSQL modules were using string formatting to insert the database name directly into the SQL query:

```python
# Before - vulnerable to SQL injection
conn.execute(text("CREATE DATABASE {0} ".format(Config.db.name)))  # mysql.py
conn.execute(text(f"CREATE DATABASE {Config.db.name}"))  # postgresql.py
```

Added a `_validate_identifier()` function that validates database names against a strict alphanumeric + underscore pattern to prevent injection.

### 3. SQLite PRAGMA injection (db.py)

The PRAGMA statements were using f-strings with unvalidated config values. Added whitelist validation for `journal_mode` and `synchronous_mode` parameters.

These are real security concerns in a security tool - we should practice what we preach! 😄