### PR TITLE
Add Wing FTP CVE-2025-47812 vulnerability module

### DIFF
--- a/nettacker/modules/vuln/wing_ftp_cve_2025_47812_vuln.yaml
+++ b/nettacker/modules/vuln/wing_ftp_cve_2025_47812_vuln.yaml
@@ -1,0 +1,35 @@
+module_name: wing_ftp_cve_2025_47812_vuln
+module_description: Detects Wing FTP Server instances vulnerable to CVE-2025-47812 (RCE via Null Byte + Lua Injection) in versions prior to 7.4.4.
+module_author:
+  - Young-Zizo
+module_type: vulnerability
+module_severity: critical
+module_profiles:
+  - vulnerabilities
+module_protocols:
+  - http
+  - https
+module_ports:
+  - 80
+  - 443
+  - 8080
+module_cves:
+  - CVE-2025-47812
+  - CVE-2025-47813
+
+payloads:
+  - library: http
+    requests:
+      - url: /loginok.html
+        method: GET
+        headers:
+          User-Agent: Nettacker
+        responses:
+          - condition_type: and
+            conditions:
+              - search_in: response_body
+                regex: "(Wing FTP Server|WingFTP|wftpserver)"
+              - search_in: response_body
+                regex: "(Wing FTP Server|Version:|WFTPServer/)(v?([0-6]\.\d+\.\d+|7\.[0-3]\.\d+|7\.4\.[0-3]))"
+              - search_in: status_code
+                regex: "200"


### PR DESCRIPTION
Fixes #1561

## Proposed change

Your PR description goes here:
This PR adds a YAML-based vulnerability detection module for Wing FTP Server to detect instances vulnerable to CVE-2025-47812. The module follows the correct syntax and is placed in the `vuln` directory.

## Type of change

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [x] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

- [x] I've followed the [contributing guidelines](https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines)
- [x] I've **digitally signed** all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [x] I've run `make test` and I confirm all tests passed locally
- [x] I've added/updated any relevant documentation in the `docs/` folder 
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [x] I've attached screenshots demonstrating that my code works as intended (if applicable)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision