### PR TITLE
Fix Windows locale directory parsing and add unit tests

### DIFF
--- a/nettacker/core/messages.py
+++ b/nettacker/core/messages.py
@@ -33,7 +33,7 @@ def get_languages():
     languages_list = []
 
     for language in Config.path.locale_dir.glob("*.yaml"):
-        languages_list.append(str(language).split("/")[-1].split(".")[0])
+        languages_list.append(language.stem)
     return list(set(languages_list))
 
 

--- a/tests/core/utils/test_common.py
+++ b/tests/core/utils/test_common.py
@@ -292,3 +292,20 @@ def test_fuzzer_repeater_perform_unknown_interceptor_alongside_allowed_raises():
 
 def test_allowed_interceptors_registry_is_restricted():
     assert set(common_utils.ALLOWED_INTERCEPTORS) == {"generate_and_replace_md5"}
+
+
+def test_get_languages():
+    from pathlib import Path
+    from nettacker.config import Config
+    from nettacker.core.messages import get_languages
+
+    mock_locale_dir = MagicMock()
+    mock_locale_dir.glob.return_value = [
+        Path("/tmp/locale/en.yaml"),
+        Path("/tmp/locale/fa.yaml"),
+        Path("C:\\locale\\fr.yaml"),  # Windows path format
+    ]
+
+    with patch.object(Config.path, "locale_dir", mock_locale_dir):
+        languages = get_languages()
+        assert sorted(languages) == ["en", "fa", "fr"]


### PR DESCRIPTION
## Proposed change

This PR fixes a platform-specific bug where the language discovery helper `get_languages()` fails to extract clean language codes (e.g., `en`, `fa`, `fr`) on Windows systems.

### Problem :-  
On Windows, path separators are backslashes (`\`). Converting the `pathlib.Path` object to a string results in `D:\path\to\locale\en.yaml`. 
The code used a hardcoded split on forward slash:
`str(language).split("/")[-1].split(".")[0]`
which fails on Windows, returning the entire path and breaking locale discovery.

### Solution :- 
Refactored `get_languages()` to use `language.stem` from `pathlib.Path`, which is cross-platform and resolves the correct filename without extension. Added a unit test in `tests/core/utils/test_common.py` to mock both Windows and Unix path formats to prevent future regressions.

Resolves  #1582

## Type of change

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [x] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've **digitally signed** all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [x] I've run `make test` and I confirm all tests passed locally
- [ ] I've added/updated any relevant documentation in the `docs/` folder 
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [x] I've attached screenshots demonstrating that my code works as intended (if applicable)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/71e4bcb8-337c-4cd7-953e-3da2b31e40af" />
