### PR TITLE
fix(messages): use pathlib stem in get_languages for cross-platform language codes

### DIFF
--- a/nettacker/core/messages.py
+++ b/nettacker/core/messages.py
@@ -33,8 +33,8 @@ def get_languages():
     languages_list = []
 
     for language in Config.path.locale_dir.glob("*.yaml"):
-        languages_list.append(str(language).split("/")[-1].split(".")[0])
-    return list(set(languages_list))
+        languages_list.append(language.stem)
+    return sorted(set(languages_list))
 
 
 class load_message:

--- a/tests/core/test_messages.py
+++ b/tests/core/test_messages.py
@@ -1,0 +1,35 @@
+from pathlib import PurePosixPath, PureWindowsPath
+from unittest.mock import patch
+
+from nettacker.core.messages import get_languages
+
+
+@patch("nettacker.core.messages.Config")
+def test_get_languages_returns_bare_sorted_codes(mock_config):
+    # Mix Windows and POSIX paths to confirm the separator is not hardcoded.
+    paths = [
+        PureWindowsPath(r"C:\nettacker\locale\fa.yaml"),
+        PureWindowsPath(r"C:\nettacker\locale\en.yaml"),
+        PurePosixPath("/opt/nettacker/locale/fr.yaml"),
+    ]
+    mock_config.path.locale_dir.glob.return_value = paths
+
+    result = get_languages()
+
+    # Bare language codes, sorted and de-duplicated, with no path or extension.
+    assert result == ["en", "fa", "fr"]
+    for code in result:
+        assert "/" not in code
+        assert "\\" not in code
+        assert "." not in code
+
+
+@patch("nettacker.core.messages.Config")
+def test_get_languages_deduplicates(mock_config):
+    mock_config.path.locale_dir.glob.return_value = [
+        PurePosixPath("/locale/en.yaml"),
+        PurePosixPath("/locale/en.yaml"),
+        PurePosixPath("/locale/de.yaml"),
+    ]
+
+    assert get_languages() == ["de", "en"]


### PR DESCRIPTION
## What

`get_languages()` built each language code with `str(language).split("/")[-1].split(".")[0]`. The `/` is hardcoded, so on Windows the separator is `\` and the split keeps the full path instead of the bare code (`en`, `fa`, ...). The UI and logs then stay stuck on English on Windows.

## Fix

`Config.path.locale_dir.glob("*.yaml")` already yields `Path` objects, so use `language.stem`, which strips the directory and extension on every platform and drops the brittle string splitting. I also switched the return to `sorted(set(...))` for deterministic ordering across runs (suggested by @arkanzasfeziii in the issue).

## Tests

Added `tests/core/test_messages.py`: it mixes Windows and POSIX paths and asserts `get_languages()` returns bare, sorted, de-duplicated codes with no separators or extensions. I confirmed it fails on the current code (the Windows paths come back as full strings) and passes with the fix.

`ruff check` and `ruff format --check` pass on the changed files.

Closes #1582