### PR TITLE
Add Pashto translations for compare scan report messages

### DIFF
--- a/nettacker/locale/ps.yaml
+++ b/nettacker/locale/ps.yaml
@@ -240,3 +240,8 @@ no_response: د هدف څخه ځواب نشي ترلاسه کولی
 category_framework: "وېشنيزه: {0}، چوکاټونه: {1} وموندل شو!"
 nothing_found: په {1} کې {1} کې هیڅ شی ندی موندلی!
 no_auth: "په {0}: {1} کې هیڅ لیک نه موندل شوی"
+compare_report_path_filename: "د پرتله کولو د سکن راپور د خوندي کولو لپاره د فایل لاره"
+no_scan_to_compare: "د پرتله کولو لپاره ورکړل شوی scan_id ونه موندل شو"
+compare_report_saved: "د پرتله کولو پایلې په {0} کې خوندي شوې"
+build_compare_report: "د پرتله کولو راپور جوړېږي"
+finish_build_report: "د پرتله کولو راپور جوړول بشپړ شول"


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker! 
  Please read and follow the instructions!
  Please DO NOT REMOVE THIS PR TEMPLATE AND THE PR CHECKLIST AT THE BOTTOM!
-->


## Proposed change

Fixes #905

Added Pashto (`ps.yaml`) translations for the newly introduced scan comparison localization strings:

* compare_report_path_filename
* no_scan_to_compare
* compare_report_saved
* build_compare_report
* finish_build_report

This change improves Pashto language support and ensures these messages are properly localized for Pashto-speaking users.

## Type of change

* [x] Documentation/localization improvement

## Checklist

* [x] I've followed the contributing guidelines
* [ ] I've digitally signed all my commits in this PR
* [ ] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
* [ ] I've run `make test` and I confirm all tests passed locally
* [ ] I've added/updated any relevant documentation in the `docs/` folder
* [ ] I've linked this PR with an open issue
* [x] I've tested and verified that my code works as intended and resolves the issue as described
* [ ] I've attached screenshots demonstrating that my code works as intended (if applicable)
* [x] I've checked all other open PRs to avoid submitting duplicate work
* [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
* [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision



<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines
