### PR TITLE
Fix report download filename and CSV handling for issue #1584

### DIFF
--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -1,10 +1,13 @@
 import csv
+import io
 import json
 import multiprocessing
 import os
 import random
 import string
 import time
+from pathlib import Path
+from pathlib import PureWindowsPath
 from threading import Thread
 from types import SimpleNamespace
 
@@ -55,6 +58,14 @@ nettacker_path_config = Config.path
 nettacker_application_config = Config.settings.as_dict()
 nettacker_application_config.update(Config.api.as_dict())
 del nettacker_application_config["api_access_key"]
+
+
+def _build_download_filename(report_path_filename: str, extension: str) -> str:
+    """Return a cross-platform report filename for download endpoints."""
+    filename = Path(report_path_filename).name
+    if filename == report_path_filename:
+        filename = PureWindowsPath(report_path_filename).name
+    return Path(filename).with_suffix(extension).name
 
 
 @app.errorhandler(400)
@@ -409,8 +420,10 @@ def get_results_json():
     if not result_id:
         return jsonify(structure(status="error", msg=_("invalid_scan_id"))), 400
     scan_details = session.query(Report).filter(Report.id == result_id).first()
+    if not scan_details:
+        return jsonify(structure(status="error", msg=_("invalid_scan_id"))), 400
     json_object = json.dumps(get_logs_by_scan_id(scan_details.scan_unique_id))
-    filename = ".".join(scan_details.report_path_filename.split(".")[:-1])[1:] + ".json"
+    filename = _build_download_filename(scan_details.report_path_filename, ".json")
     return Response(
         json_object,
         mimetype="application/json",
@@ -432,18 +445,20 @@ def get_results_csv():  # todo: need to fix time format
     if not result_id:
         return jsonify(structure(status="error", msg=_("invalid_scan_id"))), 400
     scan_details = session.query(Report).filter(Report.id == result_id).first()
+    if not scan_details:
+        return jsonify(structure(status="error", msg=_("invalid_scan_id"))), 400
     data = get_logs_by_scan_id(scan_details.scan_unique_id)
     if not data:
         return jsonify(structure(status="error", msg=_("no_scan_data_found"))), 404
     keys = data[0].keys()
-    filename = ".".join(scan_details.report_path_filename.split(".")[:-1])[1:] + ".csv"
-    with open(filename, "w") as report_path_filename:
-        dict_writer = csv.DictWriter(report_path_filename, fieldnames=keys, quoting=csv.QUOTE_ALL)
-        dict_writer.writeheader()
-        for event in data:
-            dict_writer.writerow({key: value for key, value in event.items() if key in keys})
-    with open(filename, "r") as report_path_filename:
-        reader = report_path_filename.read()
+    filename = _build_download_filename(scan_details.report_path_filename, ".csv")
+    report_buffer = io.StringIO()
+    dict_writer = csv.DictWriter(report_buffer, fieldnames=keys, quoting=csv.QUOTE_ALL)
+    dict_writer.writeheader()
+    for event in data:
+        dict_writer.writerow({key: value for key, value in event.items() if key in keys})
+    report_buffer.seek(0)
+    reader = report_buffer.getvalue()
     return Response(
         reader,
         mimetype="text/csv",

--- a/tests/api/test_engine.py
+++ b/tests/api/test_engine.py
@@ -51,3 +51,59 @@ def test_get_logs_csv_empty_data(mock_logs_to_report_json, client):
     assert response.status_code == 404
     assert response.json["status"] == "error"
     assert response.json["msg"] == "No scan data found"
+
+
+@patch("nettacker.api.engine.create_connection")
+@patch("nettacker.api.engine.get_logs_by_scan_id")
+def test_get_results_json_filename_without_path_corruption(
+    mock_get_logs, mock_create_connection, client
+):
+    """Report download filenames should be generated safely on Windows-style paths."""
+    scan_details = MagicMock(
+        scan_unique_id="abc", report_path_filename=r"C:\\tmp\\reports\\scan.2.0.html"
+    )
+    session = MagicMock()
+    session.query.return_value.filter.return_value.first.return_value = scan_details
+    mock_create_connection.return_value = session
+    mock_get_logs.return_value = [{"field": "value"}]
+
+    response = client.get(f"/results/get_json?id=1&key={API_KEY}")
+
+    assert response.status_code == 200
+    assert response.headers["Content-Disposition"] == "attachment;filename=scan.2.0.json"
+    assert response.get_data(as_text=True) == '[{"field": "value"}]'
+
+
+@patch("nettacker.api.engine.create_connection")
+@patch("nettacker.api.engine.get_logs_by_scan_id")
+def test_get_results_csv_generates_content_without_tempfile(
+    mock_get_logs, mock_create_connection, client
+):
+    """CSV report downloads should be generated in-memory and avoid temp files."""
+    scan_details = MagicMock(scan_unique_id="abc", report_path_filename="report.2026.html")
+    session = MagicMock()
+    session.query.return_value.filter.return_value.first.return_value = scan_details
+    mock_create_connection.return_value = session
+    mock_get_logs.return_value = [{"field": "value"}]
+
+    with patch("nettacker.api.engine.open") as mock_open:
+        response = client.get(f"/results/get_csv?id=1&key={API_KEY}")
+
+        assert response.status_code == 200
+        assert response.headers["Content-Disposition"] == "attachment;filename=report.2026.csv"
+        assert '"field"' in response.get_data(as_text=True)
+        assert mock_open.call_count == 0
+
+
+@patch("nettacker.api.engine.create_connection")
+def test_get_results_json_missing_scan_returns_invalid_scan_id(mock_create_connection, client):
+    """Missing scan rows should return a clear invalid_scan_id response."""
+    session = MagicMock()
+    session.query.return_value.filter.return_value.first.return_value = None
+    mock_create_connection.return_value = session
+
+    response = client.get(f"/results/get_json?id=99&key={API_KEY}")
+
+    assert response.status_code == 400
+    assert response.json["status"] == "error"
+    assert response.json["msg"] == "your scan id is not valid!"


### PR DESCRIPTION
## Summary

This PR fixes report-download issues tracked in issue #1584:

- Correctly derives download filenames from report paths so Windows-style report paths do not leak path separators in `Content-Disposition`.
- Avoids writing CSV report data to disk; response is now generated in memory.
- Returns a clear `invalid_scan_id` response when scan metadata is missing.

Closes #1584

## Changes

- Updated `/results/get_json` and `/results/get_csv` in `nettacker/api/engine.py` to use a shared filename helper with cross-platform basename handling.
- Refactored CSV response generation from temporary file write/read to in-memory `io.StringIO` generation.
- Added regression tests in `tests/api/test_engine.py` for filename safety, temp-file avoidance, and missing scan-id handling.

## Testing

Executed:

- `poetry run pytest tests/api/test_engine.py`
- `make test`
- `poetry run ruff check nettacker/api/engine.py tests/api/test_engine.py`
- `poetry run ruff format --check nettacker/api/engine.py tests/api/test_engine.py`

`make pre-commit` is not available in this environment (tool missing), so repository standard pre-commit checks were not run there.
