### PR TITLE
Fix IndexError in generate_loops() when payloads list is empty

### DIFF
--- a/nettacker/core/module.py
+++ b/nettacker/core/module.py
@@ -111,7 +111,11 @@ class Module:
     def generate_loops(self):
         if self.module_inputs["excluded_ports"]:
             excluded_port_set = set(self.module_inputs["excluded_ports"])
-            if self.module_content and "ports" in self.module_content["payloads"][0]["steps"][0]:
+            if (
+                self.module_content
+                and self.module_content["payloads"]
+                and "ports" in self.module_content["payloads"][0]["steps"][0]
+            ):
                 all_ports = self.module_content["payloads"][0]["steps"][0]["ports"]
                 all_ports[:] = [port for port in all_ports if port not in excluded_port_set]
 

--- a/tests/core/test_exclude_ports.py
+++ b/tests/core/test_exclude_ports.py
@@ -377,3 +377,46 @@ def test_generate_loops_with_excluded_ports_no_ports_in_content(
     expected_ports = [80, 443, 8080]
     actual_ports = module.module_content["payloads"][0]["steps"][0]["ports"]
     assert actual_ports == expected_ports
+
+
+@patch("nettacker.core.module.find_events")
+@patch("nettacker.core.module.TemplateLoader")
+def test_generate_loops_after_load_drops_all_payloads(
+    mock_loader_cls, mock_find_events, options, module_args
+):
+    # Reproduces issue #1636: a single-payload module whose service-discovery
+    # library was never found open (e.g. its port was closed/filtered) ends up
+    # with an empty payloads list after load(). generate_loops() must not raise
+    # IndexError on ["payloads"][0] in that state.
+    def loader_side_effect(name, inputs):
+        mock_inst = MagicMock()
+        if name == "port_scan":
+            mock_inst.load.return_value = {
+                "payloads": [{"steps": [{"response": {"conditions": {"service": {"ssh": {}}}}}]}]
+            }
+        elif name == "test_module":
+            mock_inst.load.return_value = {
+                "payloads": [
+                    {
+                        "library": "ssh",
+                        "steps": [{"ports": [22], "response": {"conditions": {"service": {}}}}],
+                    }
+                ]
+            }
+        else:
+            raise ValueError(f"Unexpected module name: {name}")
+        return mock_inst
+
+    mock_loader_cls.side_effect = loader_side_effect
+    mock_find_events.return_value = []  # ssh was not discovered open on the target
+
+    module = Module("test_module", options, **module_args)
+    module.libraries = ["ssh"]
+    module.load()
+
+    assert module.module_content["payloads"] == []
+
+    module.module_inputs["excluded_ports"] = [21]
+    module.generate_loops()  # should not raise IndexError
+
+    assert module.module_content["payloads"] == []


### PR DESCRIPTION
Closes #1636

## Proposed change

`Module.generate_loops()` in `nettacker/core/module.py` crashed with `IndexError: list index out of range` when a module has exactly one payload whose `library` is a recognized service-discovery library (ssh, ftp, smtp, smb, pop3, telnet, http, etc.), that service wasn't discovered open on the target, and `--exclude-ports` is passed.

**Root cause:** `Module.load()` deletes a payload from `self.module_content["payloads"]` when its library isn't in `self.discovered_services` but is a known service-discovery signature. For a single-payload module, this leaves `payloads == []`. `self.module_content` itself stays truthy, so the existing guard in `generate_loops()` passes straight through to `["payloads"][0]`, which raises on an empty list.

**Fix:** Added a truthiness check on `self.module_content["payloads"]` itself before indexing `[0]`, so an empty list short-circuits the port-exclusion step instead of crashing.

**Verified the fix eliminates the crash rather than relocating it** — traced the full `load() -> generate_loops() -> sort_loops() -> start()` chain:
- `sort_loops()` iterates `range(len(payloads))` -> `range(0)`, loop body never runs
- `start()`'s loops iterate zero times over `[]`; `active_threads` stays empty; `wait_for_threads_to_finish([])` returns immediately since `while threads:` is falsy on an empty list

Net effect: an all-payloads-dropped module now degrades to a clean no-op (zero requests, no exception) instead of crashing.

**Maintainer context:** @securestep9 noted on the issue that Nettacker never produces a "port closed" outcome, so this is a robustness/control-flow fix rather than a detection-accuracy fix — no false negatives/positives are introduced, since the dropped payload's service was never discovered open in the first place.

## Tests

Added `test_generate_loops_after_load_drops_all_payloads` in `tests/core/test_exclude_ports.py`. Unlike the two existing `generate_loops()` tests (which manually construct `module_content` with `payloads[0]` already present and never call `load()`), this test actually calls `load()` first — mocking `TemplateLoader`/`find_events` so a single-payload `ssh` module ends up with `payloads == []`, the real crash precondition — then calls `generate_loops()` and asserts no `IndexError` is raised. Both pre-existing tests are unchanged and still pass.

## Verification

- `ruff check`, `ruff format --check`, `isort --check-only` on both changed files: clean
- `tests/core/test_exclude_ports.py`: 10/10 passed
- Full suite: 326 passed, 6 skipped, 2 xfailed, 2 failed, 2 errors — all 4 failures/errors reproduced identically with this diff stashed (pre-existing Windows-environment issues: `test_languages_to_country` path encoding, `test_yaml_schema_and_regex_valid[subdomain_takeover.yaml]` cp1252 vs actual bytes, and missing optional deps for `test_smb.py`/`test_user_added_http_headers.py`). None touch the changed files.

## Type of change
- [x] Bugfix (non-breaking change that fixes an issue)

## Checklist
- [x] I've followed the contributing guidelines
- [x] I've digitally signed all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes *(ran ruff/isort directly — `make` unavailable on Windows)*
- [x] I've run `make test` and I confirm all tests passed locally *(ran pytest directly, see Verification above)*
- [x] I've added/updated any relevant documentation in the `docs/` folder *(N/A — internal method, no user-facing docs reference it)*
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [ ] I've attached screenshots demonstrating that my code works as intended *(N/A — internal engine logic, not UI/API-visible; test output serves as evidence)*
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision