### PR TITLE
Add vulnerability detection module for CVE-2026-33017 (Langflow unaut…

### DIFF
--- a/nettacker/modules/vuln/langflow_cve_2026_33017.yaml
+++ b/nettacker/modules/vuln/langflow_cve_2026_33017.yaml
@@ -1,0 +1,154 @@
+info:
+  name: langflow_cve_2026_33017_vuln
+  author: NSK-394
+  severity: 9.8
+  description: >
+    CVE-2026-33017 (CVSS 9.8) is an unauthenticated RCE in Langflow <= 1.8.2
+    via the /api/v1/build_public_tmp/{{flow_id}}/flow endpoint, which processes
+    attacker-controlled flow node definitions instead of using only the stored
+    flow data. The official fix in 1.9.0 removes this behavior entirely, ignoring
+    attacker-supplied node data and building only the stored (empty) flow.
+    This module detects the vulnerable input-validation flaw by submitting a
+    uniquely-identified CustomComponent node and checking whether the server's
+    build-event stream references it. Testing against 1.8.2 (vulnerable) and
+    1.9.0 (patched) shows: vulnerable instances process and reference the
+    injected node (visible as processing errors); patched instances discard
+    it before processing (empty vertex list in events). This confirms the
+    vulnerability's root cause (improper input handling); it does not
+    independently verify code execution. Non-destructive detection suitable
+    for production scanning.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33017
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx
+  profiles:
+    - vuln
+    - http
+    - critical_severity
+    - cve
+    - cve2026
+    - langflow
+    - rce
+
+payloads:
+  - library: http
+    steps:
+      # Step 1: Obtain unauthenticated access token via AUTO_LOGIN (default enabled)
+      - method: get
+        timeout: 5
+        headers:
+          User-Agent: Nettacker
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "http://{target}:7860/api/v1/auto_login"
+        response:
+          save_to_temp_events_only: token
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: access_token
+              reverse: false
+
+      # Step 2: Create a public flow (required to obtain flow_id for build endpoint)
+      - method: post
+        timeout: 5
+        headers:
+          User-Agent: Nettacker
+          Content-Type: application/json
+          Authorization: "Bearer dependent_on_temp_event[0]['content'][0]"
+        ssl: false
+        json:
+          name: nettacker_check
+          data:
+            nodes: []
+            edges: []
+          access_type: PUBLIC
+        url:
+          nettacker_fuzzer:
+            input_format: "http://{target}:7860/api/v1/flows/"
+        response:
+          dependent_on_temp_event: token
+          save_to_temp_events_only: flow_id
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "20[01]"
+              reverse: false
+            content:
+              regex: '"id"'
+              reverse: false
+
+      # Step 3: Submit attacker-controlled flow data to build_public_tmp
+      # On vulnerable versions, this node data is accepted and processed.
+      # On patched versions, it is silently discarded before graph construction.
+      - method: post
+        timeout: 10
+        headers:
+          User-Agent: Nettacker
+          Content-Type: application/json
+          Authorization: "Bearer dependent_on_temp_event[0]['content'][0]"
+          Cookie: "client_id=nettacker"
+        ssl: false
+        json:
+          data:
+            nodes:
+              - id: nettacker_vuln_check
+                type: genericNode
+                position:
+                  x: 0
+                  y: 0
+                data:
+                  type: CustomComponent
+                  id: nettacker_vuln_check
+                  node:
+                    template:
+                      _type: CustomComponent
+                      code:
+                        value: "pass"
+                        type: code
+            edges: []
+        url:
+          nettacker_fuzzer:
+            input_format: "http://{target}:7860/api/v1/build_public_tmp/dependent_on_temp_event[1]['content'][0]/flow"
+        response:
+          save_to_temp_events_only: job_id
+          dependent_on_temp_event: "token,flow_id"
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: job_id
+              reverse: false
+
+      # Step 4: Poll build-event stream to detect vulnerable behavior
+      # Vulnerable (1.8.2): server processes our injected node, error mentions our node id
+      # Patched (1.9.0): server discards our node, builds only empty flow (empty vertices list)
+      # Detection signal: presence of our distinctive node id in any event (error or otherwise)
+      # vs. absence/empty vertices list (patched). This confirms the endpoint processes
+      # attacker-supplied node data on vulnerable versions only.
+      - method: get
+        timeout: 15
+        headers:
+          User-Agent: Nettacker
+          Authorization: "Bearer dependent_on_temp_event[0]['content'][0]"
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "http://{target}:7860/api/v1/build/dependent_on_temp_event[1]['content'][0]/events"
+        response:
+          dependent_on_temp_event: "token,flow_id,job_id"
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              # Match detection: our injected node id appears anywhere in event stream
+              # (vulnerable versions reference it during processing; patched versions ignore it)
+              regex: nettacker_vuln_check
+              reverse: false


### PR DESCRIPTION
## Proposed change

New vulnerability detection module for CVE-2026-33017 (CVSS 9.8, added to CISA's
Known Exploited Vulnerabilities catalog) — an unauthenticated flow-data injection
flaw in Langflow's `/api/v1/build_public_tmp/{flow_id}/flow` endpoint.

The endpoint is designed to allow unauthenticated building of public flows, but
prior to 1.9.0 it incorrectly accepted an optional attacker-controlled `data`
parameter instead of using only the flow's stored data, allowing arbitrary
CustomComponent node definitions (including embedded Python code) to reach the
graph builder.

This module chains 3 HTTP requests:
1. `GET /api/v1/auto_login` — Langflow's default `AUTO_LOGIN=true` config issues
   an unauthenticated bearer token to any caller
2. `POST /api/v1/flows/` — creates an empty public flow using that token, capturing
   the resulting `flow_id`
3. `POST /api/v1/build_public_tmp/{flow_id}/flow` — submits a malicious
   CustomComponent node with a distinctive, uniquely-named node id

A 4th step then polls the job's build-event stream and checks whether that
distinctive node id appears — vulnerable instances process and reference the
injected node; patched instances discard it before processing entirely (empty
vertex list).

**Detection scope — important, please read before reviewing:** this module
confirms the endpoint processes attacker-controlled flow node data on vulnerable
versions (<=1.8.2) versus discarding it entirely on patched versions (>=1.9.0).
This was verified via manual `curl` testing and live Nettacker scans against both
a vulnerable (1.8.2) and patched (1.9.0) Docker container, with consistent,
repeatable results across the runs performed.

It does **not** independently confirm code execution. I was not able to get a
reliable execution-only signal (e.g. a file write or command output reflected
back) to fire in testing — the error observed during processing on the vulnerable
version appears to occur during graph/vertex construction, before the point where
the embedded code would actually be reached by `exec()`. Rather than overclaim
"RCE confirmed," the module and its description are scoped to what was actually
verified: detection of the input-validation flaw that is this CVE's root cause.
The module is non-destructive and safe to run against production targets.

Happy to iterate further on getting a genuine execution-proof signal if that's
important for merging — wanted to be upfront about the current scope rather than
overstate what's been confirmed.

## Type of change

- [x] New or existing module/payload change

## Checklist

- [x] I've followed the contributing guidelines
- [x] I've digitally signed all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes *(ran ruff/isort directly and confirmed the module loads cleanly through the real TemplateLoader with zero errors — `make` unavailable on Windows)*
- [x] I've run `make test` and I confirm all tests passed locally *(ran the existing test suite; this is a new YAML module with no dedicated unit test, consistent with other CVE modules in `nettacker/modules/vuln/`)*
- [ ] I've added/updated any relevant documentation in the `docs/` folder *(N/A — new CVE modules aren't individually documented in `docs/`, consistent with existing modules in this directory)*
- [ ] I've linked this PR with an open issue *(no open issue for this — proactively wrote this new module per @securestep9's guidance on issue #1636 that new CISA KEV detection modules are higher-value than minor robustness fixes)*
- [x] I've tested and verified that my code works as intended and resolves the issue as described *(see Detection scope note above for exact scope of what was verified)*
- [ ] I've attached screenshots demonstrating that my code works as intended *(N/A — not a UI change; verification was via curl output and Nettacker scan logs against live test containers, described above)*
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision