### PR TITLE
Fix report download filenames and stop writing the CSV to disk

### DIFF
--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -1,10 +1,12 @@
 import csv
+import io
 import json
 import multiprocessing
 import os
 import random
 import string
 import time
+from pathlib import Path
 from threading import Thread
 from types import SimpleNamespace
 
@@ -410,7 +412,7 @@ def get_results_json():
         return jsonify(structure(status="error", msg=_("invalid_scan_id"))), 400
     scan_details = session.query(Report).filter(Report.id == result_id).first()
     json_object = json.dumps(get_logs_by_scan_id(scan_details.scan_unique_id))
-    filename = ".".join(scan_details.report_path_filename.split(".")[:-1])[1:] + ".json"
+    filename = Path(scan_details.report_path_filename).with_suffix(".json").name
     return Response(
         json_object,
         mimetype="application/json",
@@ -436,16 +438,14 @@ def get_results_csv():  # todo: need to fix time format
     if not data:
         return jsonify(structure(status="error", msg=_("no_scan_data_found"))), 404
     keys = data[0].keys()
-    filename = ".".join(scan_details.report_path_filename.split(".")[:-1])[1:] + ".csv"
-    with open(filename, "w") as report_path_filename:
-        dict_writer = csv.DictWriter(report_path_filename, fieldnames=keys, quoting=csv.QUOTE_ALL)
-        dict_writer.writeheader()
-        for event in data:
-            dict_writer.writerow({key: value for key, value in event.items() if key in keys})
-    with open(filename, "r") as report_path_filename:
-        reader = report_path_filename.read()
+    filename = Path(scan_details.report_path_filename).with_suffix(".csv").name
+    report = io.StringIO()
+    dict_writer = csv.DictWriter(report, fieldnames=keys, quoting=csv.QUOTE_ALL)
+    dict_writer.writeheader()
+    for event in data:
+        dict_writer.writerow({key: value for key, value in event.items() if key in keys})
     return Response(
-        reader,
+        report.getvalue(),
         mimetype="text/csv",
         headers={"Content-Disposition": "attachment;filename=" + filename},
     )

--- a/tests/api/test_engine.py
+++ b/tests/api/test_engine.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,3 +52,53 @@ def test_get_logs_csv_empty_data(mock_logs_to_report_json, client):
     assert response.status_code == 404
     assert response.json["status"] == "error"
     assert response.json["msg"] == "No scan data found"
+
+
+@patch(
+    "nettacker.api.engine.get_logs_by_scan_id",
+    return_value=[{"target": "example.com", "date": "2026-01-01"}],
+)
+@patch("nettacker.api.engine.create_connection")
+def test_get_results_csv_filename_and_no_disk_write(
+    mock_create_connection, mock_get_logs, client, tmp_path
+):
+    """The download filename must keep every character of the report name, and
+    the CSV must be built in memory rather than left behind on disk."""
+    scan_details = MagicMock(
+        scan_unique_id="abc", report_path_filename="/tmp/results/nettacker.html"
+    )
+    session = MagicMock()
+    session.query.return_value.filter.return_value.first.return_value = scan_details
+    mock_create_connection.return_value = session
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        response = client.get(f"/results/get_csv?id=1&key={API_KEY}")
+        leftovers = list(tmp_path.iterdir())
+    finally:
+        os.chdir(cwd)
+
+    assert response.status_code == 200
+    assert response.headers["Content-Disposition"] == "attachment;filename=nettacker.csv"
+    assert leftovers == []
+
+
+@patch(
+    "nettacker.api.engine.get_logs_by_scan_id",
+    return_value=[{"target": "example.com"}],
+)
+@patch("nettacker.api.engine.create_connection")
+def test_get_results_json_filename(mock_create_connection, mock_get_logs, client):
+    """Same for the JSON endpoint: a dotted directory must not truncate the name."""
+    scan_details = MagicMock(
+        scan_unique_id="abc", report_path_filename="/home/user/.nettacker/results/scan.html"
+    )
+    session = MagicMock()
+    session.query.return_value.filter.return_value.first.return_value = scan_details
+    mock_create_connection.return_value = session
+
+    response = client.get(f"/results/get_json?id=1&key={API_KEY}")
+
+    assert response.status_code == 200
+    assert response.headers["Content-Disposition"] == "attachment;filename=scan.json"


### PR DESCRIPTION
## Proposed change

Fixes #1584.

Both report download endpoints build the attachment filename like this:

```python
filename = ".".join(scan_details.report_path_filename.split(".")[:-1])[1:] + ".json"
```

The trailing `[1:]` drops the first character of the whole joined string, so `/tmp/results/nettacker.html` becomes `tmp/results/nettacker.json` and, on Windows, `D:\reports\scan.html` becomes `:\reports\scan.csv`. Splitting on every dot also breaks paths that contain a dotted directory, which the default `.nettacker` results directory does.

This uses `Path(...).with_suffix(...).name`, which handles both and sends only the basename in `Content-Disposition`, where a directory component has no business being anyway.

The CSV endpoint additionally wrote the report to a file in the process working directory, immediately reopened it to read the contents back, and never deleted it, so every download left a file behind. That now goes through `io.StringIO`, so nothing touches disk.

## Type of change

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've **digitally signed** all my commits in this PR
- [ ] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [ ] I've run `make test` and I confirm all tests passed locally
- [ ] I've added/updated any relevant documentation in the `docs/` folder
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [ ] I've attached screenshots demonstrating that my code works as intended (if applicable)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [ ] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [ ] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

On the two unchecked boxes at the bottom: I use AI assistance as a tool while working, so rather than tick a box whose exact wording I am not certain I meet, I am saying so plainly. Every line here was written and reviewed by me, I understand each change and can defend it, and I ran the tests myself. If that does not satisfy the project's bar, tell me and I will close this.

I ran `pytest tests/api/test_engine.py` rather than the full `make test`, so I left those two boxes unticked as well. The two new tests fail on master, the filename one with `attachment;filename=home/user/.nettacker/results/scan.json` instead of `scan.json`, and pass with this change. `black --line-length 99` is clean on both files.

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines
