### PR TITLE
Replace eval/exec with explicit lookups in dependent-value resolution

### DIFF
--- a/nettacker/core/lib/base.py
+++ b/nettacker/core/lib/base.py
@@ -9,7 +9,11 @@ import yaml
 
 from nettacker.config import Config
 from nettacker.core.messages import messages as _
-from nettacker.core.utils.common import merge_logs_to_list, remove_sensitive_header_keys
+from nettacker.core.utils.common import (
+    merge_logs_to_list,
+    remove_sensitive_header_keys,
+    safe_indexed_lookup,
+)
 from nettacker.database.db import find_temp_events, submit_logs_to_db, submit_temp_logs_to_db
 from nettacker.logger import TerminalCodes, get_logger
 
@@ -67,7 +71,6 @@ class BaseEngine(ABC):
                 else:
                     if isinstance(sub_step[key], str):
                         if "dependent_on_temp_event" in sub_step[key]:
-                            globals().update(locals())
                             generate_new_step = copy.deepcopy(sub_step[key])
                             key_name = re.findall(
                                 re.compile(
@@ -76,8 +79,10 @@ class BaseEngine(ABC):
                                 generate_new_step,
                             )[0]
                             try:
-                                key_value = eval(key_name)
-                            except Exception:
+                                key_value = safe_indexed_lookup(
+                                    dependent_on_temp_event, key_name, "dependent_on_temp_event"
+                                )
+                            except (ValueError, KeyError, IndexError, TypeError):
                                 key_value = "error"
                             sub_step[key] = sub_step[key].replace(key_name, key_value)
         if isinstance(sub_step, list):
@@ -90,15 +95,16 @@ class BaseEngine(ABC):
                 else:
                     if isinstance(sub_step[value_index], str):
                         if "dependent_on_temp_event" in sub_step[value_index]:
-                            globals().update(locals())
                             generate_new_step = copy.deepcopy(sub_step[key])
                             key_name = re.findall(
                                 re.compile("dependent_on_temp_event\\['\\S+\\]\\[\\S+\\]"),
                                 generate_new_step,
                             )[0]
                             try:
-                                key_value = eval(key_name)
-                            except Exception:
+                                key_value = safe_indexed_lookup(
+                                    dependent_on_temp_event, key_name, "dependent_on_temp_event"
+                                )
+                            except (ValueError, KeyError, IndexError, TypeError):
                                 key_value = "error"
                             sub_step[value_index] = sub_step[value_index].replace(
                                 key_name, key_value

--- a/nettacker/core/lib/http.py
+++ b/nettacker/core/lib/http.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import copy
+import operator
 import random
 import re
 import time
@@ -18,6 +19,15 @@ from nettacker.core.utils.common import (
 )
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+_RESPONSETIME_OPS = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    "<=": operator.le,
+    ">": operator.gt,
+    "<": operator.lt,
+}
 
 
 async def perform_request_action(action, request_options):
@@ -73,20 +83,13 @@ def response_conditions_matched(sub_step, response):
                 except TypeError:
                     condition_results["headers"][header] = []
         if condition == "responsetime":
-            if len(conditions[condition].split()) == 2 and conditions[condition].split()[0] in [
-                "==",
-                "!=",
-                ">=",
-                "<=",
-                ">",
-                "<",
-            ]:
-                exec(
-                    "condition_results['responsetime'] = response['responsetime'] if ("
-                    + "response['responsetime'] {0} float(conditions['responsetime'].split()[-1])".format(
-                        conditions["responsetime"].split()[0]
-                    )
-                    + ") else []"
+            parts = conditions[condition].split()
+            op = _RESPONSETIME_OPS.get(parts[0]) if len(parts) == 2 else None
+            if op is not None:
+                condition_results["responsetime"] = (
+                    response["responsetime"]
+                    if op(response["responsetime"], float(parts[-1]))
+                    else []
                 )
             else:
                 condition_results["responsetime"] = []

--- a/nettacker/core/utils/common.py
+++ b/nettacker/core/utils/common.py
@@ -18,14 +18,46 @@ from nettacker import logger
 log = logger.get_logger()
 
 
+_INDEX_RE = re.compile(r"\[(-?\d+|'[^'\\]*'|\"[^\"\\]*\")\]")
+
+
+def safe_indexed_lookup(root, expression, root_name):
+    """Evaluate `root_name[i]['k'][j]...` against `root` without `eval`.
+
+    The only expressions this tool ever needs to resolve are chained integer or
+    quoted-string index lookups into `root`. `eval()` on a regex-extracted substring
+    accepted arbitrary Python, since the extracting regex (`\\S+`) matches any
+    non-whitespace character -- including code. Parsing the fixed index grammar
+    directly removes that risk class instead of trying to further sanitize the input.
+
+    Raises ValueError if `expression` is not exactly a chain of index accesses on
+    `root_name` -- callers should treat that the same as the old `except Exception`
+    fallback.
+    """
+    if not expression.startswith(root_name):
+        raise ValueError("expression does not reference %s: %r" % (root_name, expression))
+    rest = expression[len(root_name):]
+    keys = _INDEX_RE.findall(rest)
+    if "".join("[%s]" % k for k in keys) != rest:
+        raise ValueError("unsupported index expression: %r" % expression)
+
+    value = root
+    for key in keys:
+        if key[:1] in ("'", '"'):
+            value = value[key[1:-1]]
+        else:
+            value = value[int(key)]
+    return value
+
+
 def replace_dependent_response(log, response_dependent):
-    """The `response_dependent` is needed for `eval` below."""
+    """`response_dependent` is indexed into via `safe_indexed_lookup` below."""
     if str(log):
         key_name = re.findall(re.compile("response_dependent\\['\\S+\\]"), log)
         for i in key_name:
             try:
-                key_value = eval(i)
-            except Exception:
+                key_value = safe_indexed_lookup(response_dependent, i, "response_dependent")
+            except (ValueError, KeyError, IndexError, TypeError):
                 key_value = "response dependent error"
             log = log.replace(i, " ".join(key_value))
         return log

--- a/tests/core/utils/test_common.py
+++ b/tests/core/utils/test_common.py
@@ -292,3 +292,47 @@ def test_fuzzer_repeater_perform_unknown_interceptor_alongside_allowed_raises():
 
 def test_allowed_interceptors_registry_is_restricted():
     assert set(common_utils.ALLOWED_INTERCEPTORS) == {"generate_and_replace_md5"}
+
+
+def test_safe_indexed_lookup_resolves_nested_index_chain():
+    root = [{"headers": {"Set-Cookie": ["a", "session=abc123"]}}]
+    assert (
+        common_utils.safe_indexed_lookup(
+            root, "dependent_on_temp_event[0]['headers']['Set-Cookie'][1]",
+            "dependent_on_temp_event",
+        )
+        == "session=abc123"
+    )
+
+
+def test_safe_indexed_lookup_resolves_single_key():
+    root = {"foo": "bar"}
+    assert common_utils.safe_indexed_lookup(root, "response_dependent['foo']", "response_dependent") == "bar"
+
+
+def test_safe_indexed_lookup_rejects_expressions_outside_the_index_grammar():
+    """These previously reached eval(). Anything not a plain chain of index
+    accesses must raise instead of being evaluated."""
+    root = [{"a": 1}]
+    injections = [
+        "dependent_on_temp_event[__import__('os').system('id')]",
+        "dependent_on_temp_event[0].__class__",
+        "dependent_on_temp_event[0]; __import__('os').system('id')",
+        "dependent_on_temp_event[0]['a'] + open('/etc/passwd').read()",
+    ]
+    for expr in injections:
+        with pytest.raises(ValueError):
+            common_utils.safe_indexed_lookup(root, expr, "dependent_on_temp_event")
+
+
+def test_safe_indexed_lookup_rejects_wrong_root_name():
+    with pytest.raises(ValueError):
+        common_utils.safe_indexed_lookup([1], "other_name[0]", "dependent_on_temp_event")
+
+
+def test_safe_indexed_lookup_propagates_lookup_errors():
+    root = {"a": 1}
+    with pytest.raises(KeyError):
+        common_utils.safe_indexed_lookup(root, "response_dependent['missing']", "response_dependent")
+    with pytest.raises(IndexError):
+        common_utils.safe_indexed_lookup([1], "response_dependent[5]", "response_dependent")


### PR DESCRIPTION
Three places in the codebase turn module YAML content into executed Python. `globals().update(locals())` appears twice in `core/lib/base.py`. `eval(key_name)` appears twice there and once in `core/utils/common.py`. In `core/lib/http.py`, a string built with `.format()` is passed to `exec()` to evaluate `responsetime` conditions.

This replaces all of them with explicit lookups.

## Why

`key_name` is pulled out of a module YAML string by this regex:

```python
re.compile("dependent_on_temp_event\\[\\S+\\]\\['\\S+\\]\\[\\S+\\]")
```

`\S+` matches any non-whitespace character, so it will capture Python source just as readily as an index expression. Whatever it captures goes straight to `eval()`. The two `globals().update(locals())` lines exist only so that `eval` can see the local `dependent_on_temp_event`, and they copy every local in the frame into module globals as a side effect.

I want to be careful about severity, because overstating it would be a mistake. The string that reaches `eval` comes from a module YAML file, not from a scanned target's response. Response data is what gets indexed into, not what gets evaluated. So this is not remote code execution against someone running a scan, and I am not claiming it is.

What it does mean is that a module YAML can execute arbitrary Python. Module files are data, Nettacker supports user supplied modules, and people pass them around. A data file that can run code seems worth closing on its own merits, without reaching for a scarier framing than it deserves.

## How

The expressions modules actually use follow a fixed grammar. They are chains of integer or quoted string index lookups into one root object:

```yaml
Cookie: "dependent_on_temp_event[0]['headers']['Set-Cookie'][1]"   # modules/scan/subdomain.yaml
```

`safe_indexed_lookup` parses that grammar directly and rejects anything outside it. After matching the index chain it rebuilds the chain and compares it against the original text, so content wedged between or after the brackets cannot slip past:

```python
if "".join("[%s]" % k for k in keys) != rest:
    raise ValueError("unsupported index expression: %r" % expression)
```

That removes the risk class instead of sanitizing input on its way into `eval`.

For `responsetime`, the old code formatted one of six comparison operators into a string and executed it. A dict of `operator` functions does the same job, and it also removes the hardcoded operator list that had to be kept in sync with the format string.

## What stays the same

All 14 `dependent_on_temp_event` and `response_dependent` expressions in `nettacker/modules` resolve to the same values. I pulled every one of them out of the YAML and ran it through the new function.

The failure path still produces the same `"error"` and `"response dependent error"` sentinels, so callers see no difference.

The `except` clause narrows from `except Exception` to the four types the lookup can raise: `ValueError`, `KeyError`, `IndexError`, `TypeError`. If you would rather keep the blanket catch, that is an easy change.

One deliberate behaviour difference worth flagging. The grammar accepts decimal integers and quoted strings, so index forms that `eval` would have accepted, such as `[+0]`, `[0x0]` and `[True]`, now fall to the `"error"` path. Nothing in the module tree uses them, and accepting them would mean letting expression syntax back in, which is the thing being removed. Mentioning it because it is a real difference and not a pure refactor.

## Tests

Five new tests in `tests/core/utils/test_common.py`. One of them asserts that strings which previously reached `eval` now raise instead:

```python
"dependent_on_temp_event[__import__('os').system('id')]"
"dependent_on_temp_event[0].__class__"
"dependent_on_temp_event[0]; __import__('os').system('id')"
"dependent_on_temp_event[0]['a'] + open('/etc/passwd').read()"
```

Those payloads are not theoretical. The old path evaluated this:

```
dependent_on_temp_event[0]['a'][__import__('platform').system()!='']
```

It ends in a `TypeError`, but only after `__import__` has already run, because the import is part of evaluating the expression. The new path raises `ValueError` before anything is evaluated.

I also compared the `responsetime` rewrite against the old `exec` across all six operators, three response times and four malformed inputs. That is 30 cases with no differences.

`tests/core/utils/test_common.py` passes, 33 tests. I could not run the `core/lib` suites locally because they need `aiohttp`, `uvloop` and `sqlalchemy`, and `uvloop` has no Windows build, so the `base.py` and `http.py` changes rely on CI here. Saying so rather than implying I verified more than I did.

## A separate bug I did not fix

While tracing this I noticed what looks like an unrelated bug in the list branch of `find_and_replace_dependent_values`:

```python
if isinstance(sub_step, list):
    value_index = 0
    for key in copy.deepcopy(sub_step):        # key is an element, not an index
        ...
        generate_new_step = copy.deepcopy(sub_step[key])   # TypeError on a list
```

`key` iterates over list elements, so `sub_step[key]` raises `TypeError` whenever a list actually contains a `dependent_on_temp_event` string. I left it alone to keep this change to one concern. I can open a separate issue, or fold a fix in here if you prefer.
