### PR TITLE
Add vulnerability detection module for CVE-2026-20253 (Splunk Enterprise unauthenticated auth-bypass)

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -1,278 +1,360 @@
-# Nettacker Modules aka 'Methods'
+# Nettacker modules
 
-OWASP Nettacker Modules can be of type **Scan** (scan for something), **Vuln** (check for some vulnerability) and **Brute** (Brute force)
+Nettacker modules define the checks that run against a target. Each module belongs to one of
+three categories:
 
-- [Scan Modules](#scan-modules)
-- [Ports Scanned by Nettacker](#ports-scanned-by-nettacker)
-- [Vuln Modules](#vuln-modules)
-- [Brute Modules](#brute-modules)
+- **Scan** modules discover hosts, services, technologies, and other information ("scan" for something).
+- **Vuln** (**Vulnerability**) modules check for a specific vulnerability (e.g. a CVE) or insecure configuration.
+- **Brute** (**Brute-force**) modules test authentication using supplied or module-defined credentials.
 
-## Scan Modules
+> Only scan systems you own or have explicit permission to test!
 
-- '**adobe_aem_lastpatcheddate_scan**' - Scan the target for Adobe Experience Manager (AEM) and return its last patched date
-- '**admin_scan**' - Scan the target for various Admin folders such as /admin /phpmyadmin /cmsadmin /wp-admin etc
-- '**citrix_lastpatcheddate_scan**' - Scan the target and try to detect Citrix Netscaler Gateway and it's last patched date
-- '**config_file_scan**' - Scan the target for various exposed configuration files
-- '**confluence_version_scan**' - Scan the target and identify the Confluence version
-- '**crushftp_lastpatcheddate_scan**' - Scan the target and try to detect CrushFTP and its last patched date
-- '**cups_version_scan**' - Scan the target and identify the CUPS version (on port 631)
-- '**dir_scan**' - Scan the target for well-known directories
-- '**drupal_modules_scan**' - Scan the target for popular Drupal modules
-- '**drupal_theme_scan**' - Scan the target for popular Drupal themes
-- '**drupal_version_scan**' - Scan the target and identify the Drupal version
-- '**http_html_title_scan**' - Scan the target and extracts HTML title for service identification
-- '**http_redirect_scan**' - Scan the target and test if it returns an HTTP redirect 3xx response code and print the destination
-- '**http_status_scan**' - Scan the target and return the HTTP status code
-- '**icmp_scan**' - Ping the target and log the response time if it responds.
-- '**ivanti_csa_lastpatcheddate_scan**' - Scan the target for Ivanti CSA appliance and return its last patched date
-- '**ivanti_epmm_lastpatcheddate_scan**' - Scan the target for Ivanti EPMM last patched date via headers
-- '**ivanti_ics_lastpatcheddate_scan**' - Scan the target for Ivanti ICS last patched date via headers
-- '**ivanti_vtm_version_scan**' - Scan the target for Ivanti vTM appliance and return its version number
-- '**jenkins_version_scan**' - Scan the target for Jenkins automation server software version
-- '**joomla_template_scan**' - Scan the target for Joomla templates (identify Joomla sites)
-- '**joomla_user_enum_scan**' - Scan the target and enumerate Joomla users
-- '**joomla_version_scan**' - Scan the target and identify the Joomla version
-- '**moveit_version_scan**' - Scan the target and identify the Progress MOVEit version
-- '**pma_scan**' - Scan the target for PHP MyAdmin presence
-- '**port_scan**' - Scan the target for open ports identifying the popular services using signatures (.e.g SSH on port 2222)
-- '**smartermail_version_scan**' - Scan the target and identify the SmarterMail version
-- '**ssl_expiring_certificate_scan**' - Scan the target for SSL/TLS certificates nearing expiration
-- '**subdomain_scan**' - Scan the target for subdomains (target must be a domain e.g. owasp.org)
-- '**viewdns_reverse_iplookup_scan**' - Identify which sites/domains are hosted on the target host using ViewDNS.info
-- '**waf_scan**' - Scan the target to detect the presence of a Web Application Firewall
-- '**web_technologies_scan**' - Scan the target to identify web technologies and frameworks
-- '**wordpress_version_scan**' - Scan the target and identify the WordPress version
-- '**wp_plugin_scan**' - Scan the target for popular WordPress Plugins
-- '**wp_theme_scan**' - Scan the target for popular WordPress themes
-- '**wp_timethumbs_scan**' - Scan the target for WordPress TimThumb.php script in various possible locations
 
-## Ports Scanned by Nettacker
+## On this page
 
-If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacker will scan for these 1000 most popular ports:
+- [Find and select modules](#find-and-select-modules)
+- [Ports and service discovery](#ports-and-service-discovery)
+- [Module-specific values](#module-specific-values)
+- [Available modules](#available-modules)
+  - [Scan modules](#scan-modules)
+  - [Vulnerability modules](#vulnerability-modules)
+  - [Brute-force modules](#brute-force-modules)
 
-`[1, 3, 4, 6, 7, 9, 13, 17, 19, 20, 21, 22, 23, 24, 25, 26, 30, 32, 33, 37, 42,`
-`43, 49, 53, 67, 68, 69, 70, 79, 80, 81, 82, 83, 84, 85, 88, 89, 90, 99, 100, 106, 109, 110,`
-`111, 113, 119, 125, 135, 139, 143, 144, 146, 161, 162, 163, 179, 199, 211, 212, 222,`
-`254, 255, 256, 259, 264, 280, 301, 306, 311, 340, 366, 389, 406, 407, 416, 417,`
-`425, 427, 443, 444, 445, 458, 464, 465, 481, 497, 500, 512, 513, 514, 515, 524,`
-`541, 543, 544, 545, 548, 554, 555, 563, 587, 593, 616, 617, 625, 631, 636, 646,`
-`648, 666, 667, 668, 683, 687, 691, 700, 705, 711, 714, 720, 722, 726, 749, 765,`
-`777, 783, 787, 800, 801, 808, 843, 873, 880, 888, 898, 900, 901, 902, 903, 911,`
-`912, 981, 987, 990, 992, 993, 995, 999, 1000, 1001, 1002, 1007, 1009, 1010,`
-`1011, 1021, 1022, 1023, 1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032,`
-`1033, 1034, 1035, 1036, 1037, 1038, 1039, 1040, 1041, 1042, 1043, 1044, 1045,`
-`1046, 1047, 1048, 1049, 1050, 1051, 1052, 1053, 1054, 1055, 1056, 1057, 1058,`
-`1059, 1060, 1061, 1062, 1063, 1064, 1065, 1066, 1067, 1068, 1069, 1070, 1071,`
-`1072, 1073, 1074, 1075, 1076, 1077, 1078, 1079, 1080, 1081, 1082, 1083, 1084,`
-`1085, 1086, 1087, 1088, 1089, 1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097,`
-`1098, 1099, 1100, 1102, 1104, 1105, 1106, 1107, 1108, 1110, 1111, 1112, 1113,`
-`1114, 1117, 1119, 1121, 1122, 1123, 1124, 1126, 1130, 1131, 1132, 1137, 1138,`
-`1141, 1145, 1147, 1148, 1149, 1151, 1152, 1154, 1163, 1164, 1165, 1166, 1169,`
-`1174, 1175, 1183, 1185, 1186, 1187, 1192, 1198, 1199, 1201, 1213, 1216, 1217,`
-`1218, 1233, 1234, 1236, 1244, 1247, 1248, 1259, 1271, 1272, 1277, 1287, 1296,`
-`1300, 1301, 1309, 1310, 1311, 1322, 1328, 1334, 1352, 1417, 1433, 1434, 1443,`
-`1455, 1461, 1494, 1500, 1501, 1503, 1521, 1524, 1533, 1556, 1580, 1583, 1594,`
-`1600, 1641, 1658, 1666, 1687, 1688, 1700, 1717, 1718, 1719, 1720, 1721, 1723,`
-`1755, 1761, 1782, 1783, 1801, 1805, 1812, 1839, 1840, 1862, 1863, 1864, 1875,`
-`1900, 1914, 1935, 1947, 1971, 1972, 1974, 1984, 1998, 1999, 2000, 2001, 2002,`
-`2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2013, 2020, 2021, 2022, 2030,`
-`2033, 2034, 2035, 2038, 2040, 2041, 2042, 2043, 2045, 2046, 2047, 2048, 2049,`
-`2065, 2068, 2099, 2100, 2103, 2105, 2106, 2107, 2111, 2119, 2121, 2126, 2135,`
-`2144, 2160, 2161, 2170, 2179, 2190, 2191, 2196, 2200, 2222, 2251, 2260, 2288,`
-`2301, 2323, 2366, 2381, 2382, 2383, 2393, 2394, 2399, 2401, 2492, 2500, 2522,`
-`2525, 2557, 2601, 2602, 2604, 2605, 2607, 2608, 2638, 2701, 2702, 2710, 2717,`
-`2718, 2725, 2800, 2809, 2811, 2869, 2875, 2909, 2910, 2920, 2967, 2968, 2998,`
-`3000, 3001, 3003, 3005, 3006, 3007, 3011, 3013, 3017, 3030, 3031, 3052, 3071,`
-`3077, 3128, 3168, 3211, 3221, 3260, 3261, 3268, 3269, 3283, 3300, 3301, 3306,`
-`3322, 3323, 3324, 3325, 3333, 3351, 3367, 3369, 3370, 3371, 3372, 3389, 3390,`
-`3404, 3476, 3493, 3517, 3527, 3546, 3551, 3580, 3659, 3689, 3690, 3703, 3737,`
-`3766, 3784, 3800, 3801, 3809, 3814, 3826, 3827, 3828, 3851, 3869, 3871, 3878,`
-`3880, 3889, 3905, 3914, 3918, 3920, 3945, 3971, 3986, 3995, 3998, 4000, 4001,`
-`4002, 4003, 4004, 4005, 4006, 4045, 4111, 4125, 4126, 4129, 4224, 4242, 4279,`
-`4321, 4343, 4443, 4444, 4445, 4446, 4449, 4550, 4567, 4662, 4848, 4899, 4900,`
-`4998, 5000, 5001, 5002, 5003, 5004, 5009, 5030, 5033, 5050, 5051, 5054, 5060,`
-`5061, 5080, 5087, 5100, 5101, 5102, 5120, 5190, 5200, 5214, 5221, 5222, 5225,`
-`5226, 5269, 5280, 5298, 5357, 5405, 5414, 5431, 5432, 5440, 5500, 5510, 5544,`
-`5550, 5555, 5560, 5566, 5631, 5633, 5666, 5678, 5679, 5718, 5730, 5800, 5801,`
-`5802, 5810, 5811, 5815, 5822, 5825, 5850, 5859, 5862, 5877, 5900, 5901, 5902,`
-`5903, 5904, 5906, 5907, 5910, 5911, 5915, 5922, 5925, 5950, 5952, 5959, 5960,`
-`5961, 5962, 5963, 5987, 5988, 5989, 5998, 5999, 6000, 6001, 6002, 6003, 6004,`
-`6005, 6006, 6007, 6009, 6025, 6059, 6100, 6101, 6106, 6112, 6123, 6129, 6156,`
-`6346, 6389, 6502, 6510, 6543, 6547, 6565, 6566, 6567, 6580, 6646, 6666, 6667,`
-`6668, 6669, 6689, 6692, 6699, 6779, 6788, 6789, 6792, 6839, 6881, 6901, 6969,`
-`7000, 7001, 7002, 7004, 7007, 7019, 7025, 7070, 7100, 7103, 7106, 7200, 7201,`
-`7402, 7435, 7443, 7496, 7512, 7625, 7627, 7676, 7741, 7777, 7778, 7800, 7911,`
-`7920, 7921, 7937, 7938, 7999, 8000, 8001, 8002, 8007, 8008, 8009, 8010, 8011,`
-`8021, 8022, 8031, 8042, 8045, 8080, 8081, 8082, 8083, 8084, 8085, 8086, 8087,`
-`8088, 8089, 8090, 8093, 8099, 8100, 8180, 8181, 8192, 8193, 8194, 8200, 8222,`
-`8254, 8290, 8291, 8292, 8300, 8333, 8383, 8400, 8402, 8443, 8500, 8600, 8649,`
-`8651, 8652, 8654, 8701, 8800, 8873, 8888, 8899, 8994, 9000, 9001, 9002, 9003,`
-`9009, 9010, 9011, 9040, 9050, 9071, 9080, 9081, 9090, 9091, 9099, 9100, 9101,`
-`9102, 9103, 9110, 9111, 9200, 9207, 9220, 9290, 9415, 9418, 9485, 9500, 9502,`
-`9503, 9535, 9575, 9593, 9594, 9595, 9618, 9666, 9876, 9877, 9878, 9898, 9900,`
-`9917, 9929, 9943, 9944, 9968, 9998, 9999, 10000, 10001, 10002, 10003, 10004,`
-`10009, 10010, 10012, 10024, 10025, 10082, 10180, 10215, 10243, 10566, 10616,`
-`10617, 10621, 10626, 10628, 10629, 10778, 11110, 11111, 11967, 12000, 12174,`
-`12265, 12345, 13456, 13722, 13782, 13783, 14000, 14238, 14441, 14442, 15000,`
-`15002, 15003, 15004, 15660, 15742, 16000, 16001, 16012, 16016, 16018, 16080,`
-`16113, 16992, 16993, 17877, 17988, 18040, 18101, 18988, 19101, 19283, 19315,`
-`19350, 19780, 19801, 19842, 20000, 20005, 20031, 20221, 20222, 20828, 21571,`
-`22939, 23502, 24444, 24800, 25734, 25735, 26214, 27000, 27352, 27353, 27355,`
-`27356, 27715, 28201, 30000, 30718, 30951, 31038, 31337, 32768, 32769, 32770,`
-`32771, 32772, 32773, 32774, 32775, 32776, 32777, 32778, 32779, 32780, 32781,`
-`32782, 32783, 32784, 32785, 33354, 33899, 34571, 34572, 34573, 35500, 38292,`
-`40193, 40911, 41511, 42510, 44176, 44442, 44443, 44501, 45100, 48080, 49152,`
-`49153, 49154, 49155, 49156, 49157, 49158, 49159, 49160, 49161, 49163, 49165,`
-`49167, 49175, 49176, 49400, 49999, 50000, 50001, 50002, 50003, 50006, 50300,`
-`50389, 50500, 50636, 50800, 51103, 51493, 52673, 52822, 52848, 52869, 54045,`
-`54328, 55055, 55056, 55555, 55600, 56737, 56738, 57294, 57797, 58080, 60020,`
-`60443, 61532, 61900, 62078, 63331, 64623, 64680, 65000, 65129, 65389]`
+## Find and select modules
 
-## Vuln Modules
+Module identifiers end in `_scan`, `_vuln`, or `_brute`. Identifiers are case-sensitive and must
+be passed exactly as shown by the CLI:
 
-- '**aiohttp_cve_2024_23334_vuln**' - check the target for CVE-2024-23334
-- '**apache_ofbiz_cve_2024_38856**' - check the target for Apache OFBiz CVE-2024-38856
-- '**apache_struts_vuln**' - check Apache Struts for CVE-2017-5638
-- '**Bftpd_double_free_vuln**' - check bftpd for CVE-2007-2010
-- '**Bftpd_memory_leak_vuln**' - check bftpd for CVE-2017-16892
-- '**Bftpd_parsecmd_overflow_vuln**'- check bftpd for CVE-2007-2051
-- '**Bftpd_remote_dos_vuln**' - check bftpd for CVE-2009-4593
-- '**CCS_injection_vuln**' - check SSL for Change Cipher Spec (CCS Injection) CVE-2014-0224
-- '**citrix_cve_2019_19781_vuln**' - check the target for Citrix CVE-2019-19781 vulnerability
-- '**citrix_cve_2023_24488_vuln**' - check the target for Citrix CVE-2023-24488 XSS vulnerability
-- '**clickjacking_vuln**' - check the web server for missing 'X-Frame-Options' header (clickjacking protection)
-- '**content_security_policy_vuln**' - check the web server for missing 'Content-Security-Policy' header
-- '**content_type_options_vuln**' - check the web server for missing 'X-Content-Type-Options'=nosniff header
-- '**crushftp_cve_2025_31161_vuln**' - check the target for CrushFTP CVE-2025-31161 vulnerability
-- '**f5_cve_2020_5902_vuln**' - check the target for F5 RCE CVE-2020-5902 vulnerability
-- '**geoserver_cve_2024_36401_vuln**' - check the target for CVE-2024-36401 vulnerability
-- '**heartbleed_vuln**' - check SSL for Heartbleed vulnerability (CVE-2014-0160)
-- '**msexchange_cve_2021_26855**' - check the target for MS Exchange SSRF CVE-2021-26855 (proxylogon/hafnium)
-- '**nextjs_cve_2025_55182_vuln**' - check the target for CVE-2025-55182(React2Shell)
-- '**http_cors_vuln**' - check the web server for overly-permissive CORS (header 'Access-Control-Allow-Origin'=\*)
-- '**joomla_cve_2023_23752_vuln**' - check the target for Joomla CVE-2023-23752 information disclosure vulnerability
-- '**options_method_enabled_vuln**' - check if OPTIONS method is enabled on the web server
-- '**paloalto_panos_cve_2025_0108_vuln**' - check the target for PaloAlto PAN-OS CVE-2025-0108 vulnerability
-- '**paloalto_globalprotect_cve_2025_0133_vuln**' - check the target for PaloAlto GlobalProtect CVE-2025-0133 XSS vulnerability
-- '**ProFTPd_bypass_sqli_protection_vuln**' - check ProFTPd for CVE-2009-0543
-- '**ProFTPd_cpu_consumption_vuln**' - check ProFTPd for CVE-2008-7265
-- '**ProFTPd_directory_traversal_vuln**' - check ProFTPd for CVE-2010-3867
-- '**ProFTPd_exec_arbitary_vuln**' - check ProFTPd for CVE-2011-4130
-- '**ProFTPd_heap_overflow_vuln**' - check ProFTPd for CVE-2010-4652
-- '**ProFTPd_integer_overflow_vuln**' - check ProFTPd for CVE-2011-1137
-- '**ProFTPd_memory_leak_vuln**' - check ProFTPd for CVE-2001-0136
-- '**ProFTPd_restriction_bypass_vuln**' - check ProFTPd for CVE-2009-3639
-- '**server_version_vuln**' - check if the web server is leaking server banner in 'Server' response header
-- '**siyuan_cve_2026_34605_vuln**' - check for reflected SVG XSS vulnerability CVE-2026-34605
-- '**smartermail_cve_2026_24423_vuln**' - check the target for SmarterMail CVE-2026-24423 vulnerability
-- '**sonicwall_sslvpn_cve_2024_53704_vuln**' - check the target for SonicWALL SSLVPN CVE-2024-53704 vulnerability
-- '**ssl_signed_certificate_vuln**' - check for self-signed & other signing issues(weak signing algorithm) in SSL certificate
-- '**ssl_expired_certificate_vuln**' - check if SSL certificate has expired or is close to expiring
-- '**ssl_version_vuln**' - check if the server's SSL configuration supports old and insecure SSL versions
-- '**ssl_weak_cipher_vuln**' - check if server's SSL configuration supports weak cipher suites
-- '**wordpress_dos_cve_2018_6389_vuln**' - check if Wordpress is vulnerable to CVE-2018-6389 Denial Of Service (DOS)
-- '**wp_plugin_cve_2023_47668_vuln**' - check the target for CVE-2023-47668
-- '**wp_xmlrpc_bruteforce_vuln**' - check if Wordpress is vulnerable to credential Brute Force via XMLRPC wp.getUsersBlogs
-- '**wp_xmlrpc_pingback_vuln**' - check if Wordpress is vulnerable to XMLRPC pingback
-- '**x_powered_by_vuln**' - check if the web server is leaking server configuration in 'X-Powered-By' response header
-- '**xdebug_rce_vuln**' - checks if web server is running XDebug version 2.5.5 vulnerable to RCE
-- '**XSS_protection_vuln**' - check if header 'X-XSS-Protection' header is set to '1; mode=block'
-- '**vite_cve_2025_31125_vuln**' - check the target for CVE-2025-31125
-- '**vbulletin_cve_2019_16759_vuln**' - check the target for vBulletin RCE CVE-2019-16759 vulnerability
-- '**accela_cve_2021_34370_vuln**' – check for authentication bypass vulnerability in Accela Civic Platform
-- '**adobe_coldfusion_cve_2023_26360_vuln**' – check the target for Adobe ColdFusion CVE-2023-26360 insecure deserialization RCE vulnerability
-- '**adobe_coldfusion_cve_2026_48282_vuln**' - check the target for Adobe ColdFusion CVE-2026-48282 RDS path traversal vulnerability
-- '**aiohttp_cve_2024_23334_vuln**' – check the target for CVE-2024-23334
-- '**apache_cve_2021_41773_vuln**' – check for path traversal vulnerability in Apache HTTP Server
-- '**apache_cve_2021_42013_vuln**' – check for remote code execution vulnerability in Apache HTTP Server
-- '**apache_ofbiz_cve_2024_38856_vuln**' – check the target for CVE-2024-38856 in Apache OFBiz
-- '**apache_struts_vuln**' – check Apache Struts for CVE-2017-5638
-- '**aviatrix_cve_2021_40870_vuln**' – check the target for Aviatrix CVE-2021-40870 vulnerability
-- '**cisco_hyperflex_cve_2021_1497_vuln**' – check the target for Cisco HyperFlex CVE-2021-1497
-- '**citrix_cve_2019_19781_vuln**' – check the target for Citrix CVE-2019-19781 vulnerability
-- '**citrix_cve_2023_24488_vuln**' – check the target for Citrix CVE-2023-24488 XSS vulnerability
-- '**citrix_cve_2023_4966_vuln**' – check the target for Citrix CVE-2023-4966 vulnerability
-- '**clickjacking_vuln**' – check the web server for missing 'X-Frame-Options' header (clickjacking protection)
-- '**cloudron_cve_2021_40868_vuln**' – check the target for Cloudron CVE-2021-40868 vulnerability
-- '**confluence_cve_2023_22515_vuln**' – check the target for Confluence CVE-2023-22515 vulnerability
-- '**confluence_cve_2023_22527_vuln**' – check the target for Confluence CVE-2023-22527 vulnerability
-- '**content_security_policy_vuln**' – check the web server for missing 'Content-Security-Policy' header
-- '**content_type_options_vuln**' – check the web server for missing 'X-Content-Type-Options'=nosniff header
-- '**crushftp_cve_2025_31161_vuln**' – check the target for CrushFTP CVE-2025-31161 vulnerability
-- '**cyberoam_netgenie_cve_2021_38702_vuln**' – check the target for Cyberoam NetGenie CVE-2021-38702
-- '**exponent_cms_cve_2021_38751_vuln**' – check the target for Exponent CMS CVE-2021-38751
-- '**f5_cve_2020_5902_vuln**' – check the target for F5 RCE CVE-2020-5902 vulnerability
-- '**forgerock_am_cve_2021_35464_vuln**' – check the target for ForgeRock AM CVE-2021-35464
-- '**galera_webtemp_cve_2021_40960_vuln**' – check the target for Galera WebTemplate CVE-2021-40960
-- '**grafana_cve_2021_43798_vuln**' – check the target for Grafana CVE-2021-43798 vulnerability
-- '**graphql_vuln**' – check the target for exposed GraphQL introspection endpoint
-- '**gurock_testrail_cve_2021_40875_vuln**' – check the target for TestRail CVE-2021-40875 vulnerability
-- '**hoteldruid_cve_2021_37833_vuln**' – check the target for HotelDruid CVE-2021-37833 XSS vulnerability
-- '**http_cookie_vuln**' – check the web server for insecure HTTP cookie attributes
-- '**http_cors_vuln**' – check the web server for overly-permissive CORS configuration
-- '**http_options_enabled_vuln**' – check if OPTIONS method is enabled on the web server
-- '**ivanti_epmm_cve_2023_35082_vuln**' – check the target for Ivanti EPMM CVE-2023-35082 vulnerability
-- '**ivanti_ics_cve_2023_46805_vuln**' – check the target for Ivanti ICS CVE-2023-46805 vulnerability
-- '**joomla_cve_2023_23752_vuln**' – check the target for Joomla CVE-2023-23752 information disclosure
-- '**justwriting_cve_2021_41878_vuln**' – check the target for JustWriting CVE-2021-41878
-- '**langflow_cve_2025_3248_vuln**' - check the target for Langflow CVE-2025-3248 vulnerability
-- '**log4j_cve_2021_44228_vuln**' – check the target for Log4Shell CVE-2021-44228 vulnerability
-- '**majordomo_rce_cve_2026_27174_vuln**' – check for MajorDoMo CVE-2026-27174 vulnerability
-- '**maxsite_cms_cve_2021_35265_vuln**' – check the target for MaxSite CMS CVE-2021-35265
-- '**memos_cve_2025_22952_ssrf_vuln**' – check vulnerable Memos markdown metadata endpoint CVE-2025-22952
-- '**meteobridge_cve_2025_4008_vuln**' - check for MeteoBridge unauthenticated command injection CVE-2025-4008
-- '**msexchange_cve_2021_26855_vuln**' – check the target for MS Exchange SSRF CVE-2021-26855
-- '**msexchange_cve_2021_34473_vuln**' – check the target for MS Exchange CVE-2021-34473 vulnerability
-- '**nexus_cve_2024_4956_vuln**' – Detects Sonatype Nexus Repository Manager CVE-2024-4956, an unauthenticated path traversal vulnerability that allows arbitrary file read.
-- '**novnc_cve_2021_3654_vuln**' – check the target for noVNC CVE-2021-3654 vulnerability
-- '**nginx_ui_cve_2026_33032_vuln**' – check unauthenticated MCP endpoint exposure vulnerability CVE-2026-33032
-- '**omigod_cve_2021_38647_vuln**' – check the target for OMIGOD CVE-2021-38647 vulnerability
-- '**paloalto_globalprotect_cve_2025_0133_vuln**' – check the target for PaloAlto GlobalProtect CVE-2025-0133 XSS vulnerability
-- '**paloalto_panos_cve_2025_0108_vuln**' – check the target for PaloAlto PAN-OS CVE-2025-0108 vulnerability
-- '**payara_cve_2021_41381_vuln**' – check the target for Payara CVE-2021-41381 vulnerability
-- '**phpinfo_cve_2021_37704_vuln**' – check the target for phpinfo CVE-2021-37704 information disclosure
-- '**placeos_cve_2021_41826_vuln**' – check the target for PlaceOS CVE-2021-41826 vulnerability
-- '**prestashop_cve_2021_37538_vuln**' – check the target for PrestaShop CVE-2021-37538 vulnerability
-- '**puneethreddyhc_sqli_cve_2021_41648_vuln**' – check the target for SQL injection CVE-2021-41648
-- '**puneethreddyhc_sqli_cve_2021_41649_vuln**' – check the target for SQL injection CVE-2021-41649
-- '**qsan_storage_xss_cve_2021_37216_vuln**' – check the target for QSAN CVE-2021-37216 XSS vulnerability
-- '**server_version_vuln**' – check if the web server is leaking server banner in 'Server' response header
-- '**sonicwall_sslvpn_cve_2024_53704_vuln**' – check the target for SonicWall SSLVPN CVE-2024-53704 vulnerability
-- '**splunk_cve_2026_20253_vuln**' – check the target for Splunk Enterprise CVE-2026-20253 unauthenticated auth-bypass vulnerability
-- '**ssl_certificate_weak_signature_vuln**' – check SSL certificate for weak signing algorithms
-- '**ssl_expired_certificate_vuln**' – check if SSL certificate has expired or is close to expiring
-- '**ssl_self_signed_certificate_vuln**' – check for self-signed SSL certificates
-- '**ssl_weak_cipher_vuln**' – check if server's SSL configuration supports weak cipher suites
-- '**ssl_weak_version_vuln**' – check if the server's SSL configuration supports weak protocol versions
-- '**strict_transport_security_vuln**' – check for missing Strict-Transport-Security header
-- '**subdomain_takeover_vuln**' – check the target for potential subdomain takeover
-- '**teamcity_cve_2024_27198_vuln**' – check the target for TeamCity CVE-2024-27198 vulnerability
-- '**tieline_cve_2021_35336_vuln**' – check the target for Tieline CVE-2021-35336 vulnerability
-- '**tjws_cve_2021_37573_vuln**' – check the target for TJWS CVE-2021-37573 vulnerability
-- '**vbulletin_cve_2019_16759_vuln**' – check the target for vBulletin CVE-2019-16759 vulnerability
-- '**wordpress_core_cve_2026_63030_vuln**' – check the target for WordPress core CVE-2026-63030 
-- '**wp_plugin_cve_2021_38314_vuln**' – check the target for WordPress plugin CVE-2021-38314
-- '**wp_plugin_cve_2021_39316_vuln**' – check the target for WordPress plugin CVE-2021-39316
-- '**wp_plugin_cve_2021_39320_vuln**' – check the target for WordPress plugin CVE-2021-39320
-- '**wp_plugin_cve_2023_47668_vuln**' – check the target for WordPress plugin CVE-2023-47668
-- '**wp_plugin_cve_2023_6875_vuln**' – check the target for WordPress plugin CVE-2023-6875
-- '**wp_xmlrpc_bruteforce_vuln**' – check if WordPress XML-RPC brute force is possible
-- '**wp_xmlrpc_dos_vuln**' – check if WordPress XML-RPC denial of service is possible
-- '**wp_xmlrpc_pingback_vuln**' – check if WordPress XML-RPC pingback is enabled
-- '**xdebug_rce_vuln**' – check if Xdebug is vulnerable to remote code execution
-- '**x_powered_by_vuln**' – check if the web server is leaking server configuration in 'X-Powered-By' response header
-- '**x_xss_protection_vuln**' – check if header 'X-XSS-Protection' is missing or misconfigured
-- '**zoho_cve_2021_40539_vuln**' – check the target for Zoho CVE-2021-40539 vulnerability
+```console
+python nettacker.py --show-all-modules
+python nettacker.py --show-all-profiles
+```
 
-## Brute Modules
+`--show-all-modules` is the authoritative source for the installed version. It includes each
+module's description, author, severity, references, and profiles.
 
-If no extra users/passwords parameters are specified the following default usernames will be used on brute force checks: ["admin", "root", "test", "ftp", "anonymous", "user", "support", "1"] with the following passwords: ["admin", "root", "test", "ftp", "anonymous", "user", "1", "12345",123456", "124567", "12345678", "123456789", "1234567890", "admin1", "password!@#", "support", "1qaz2wsx", "qweasd", "qwerty", "!QAZ2wsx","password1", "1qazxcvbnm", "zxcvbnm", "iloveyou", "password", "p@ssw0rd","admin123", ""]
+Run one module, or separate multiple modules with commas:
 
-- '**ftp_brute**' - try to brute force FTP users.
-- '**http_basic_auth_brute**' - try to brute for HTTP Basic Auth users.
-- '**http_form_brute**' - try to brute force using HTTP form - assuming that the form has 'username' and 'password' fields
-- '**http_ntlm_brute**' - try to brute force using HTTP NTLM
-- '**smtp_brute**' - - try to brute force SMTP (ports ["25", "465", "587"])
-- '**ssh_brute**' - try to brute force SSH (port 22)
-- '**telnet_brute**' - try to brute force via telnet (port23) (expects "login" and "Password" prompt)
-- '**wp_xmlrpc_brute**' - try to brute force Wordpress users using XMLRPC and wp.getUsersBlogs method
+```console
+python nettacker.py -i scanme.example -m http_status_scan
+python nettacker.py -i scanme.example \
+  -m http_status_scan,ssl_expiring_certificate_scan
+```
+
+Profiles select every module tagged with a particular capability or technology. Profiles and
+explicit module selections can be combined, and `-x` excludes modules from the result:
+
+```console
+python nettacker.py -i scanme.example --profile http
+python nettacker.py -i scanme.example --profile http -x dir_scan,admin_scan
+```
+
+See the [usage guide](Usage.md) for all target, output, concurrency, and reporting options.
+
+## Ports and service discovery
+
+Nettacker normally performs service discovery (port scan of 1,005 most-popular ports) before running modules and limits protocol-specific
+checks to compatible discovered services. Use `-d` or `--skip-service-discovery` only when you
+intentionally want to run selected modules without that filtering.
+
+The `port_scan` module's default ports are maintained in
+[`nettacker/modules/scan/port.yaml`](../nettacker/modules/scan/port.yaml). 
+
+Use `-g` or `--ports` to replace the default selection. Use `-X` or `--exclude-ports` to remove ports
+from the effective selection. Both options accept a single port, comma-separated ports, inclusive
+ranges, or a mixture of those forms. Exclusions are applied after the default or `--ports`
+selection:
+
+
+```console
+python nettacker.py -i scanme.example -m port_scan -g 22,80,443,8000-8100
+python nettacker.py -i scanme.example -m port_scan -X 25,110,445
+```
+
+`-g 1-65535` requests all TCP ports. A full-port scan is substantially slower and noisier than the
+default selection.
+
+<details open>
+<summary>Show the 1,005 default ports used by <code>port_scan</code></summary>
+
+```text
+1, 3, 4, 6, 7, 9, 13, 17, 19, 20, 21, 22, 23, 24, 25, 26
+30, 32, 33, 37, 42, 43, 49, 53, 67, 68, 69, 70, 79, 80, 81, 82
+83, 84, 85, 88, 89, 90, 99, 100, 106, 109, 110, 111, 113, 119, 125, 135
+139, 143, 144, 146, 161, 162, 163, 179, 199, 211, 212, 222, 254, 255, 256, 259
+264, 280, 301, 306, 311, 340, 366, 389, 406, 407, 416, 417, 425, 427, 443, 444
+445, 458, 464, 465, 481, 497, 500, 512, 513, 514, 515, 524, 541, 543, 544, 545
+548, 554, 555, 563, 587, 593, 616, 617, 625, 631, 636, 646, 648, 666, 667, 668
+683, 687, 691, 700, 705, 711, 714, 720, 722, 726, 749, 765, 777, 783, 787, 800
+801, 808, 843, 873, 880, 888, 898, 900, 901, 902, 903, 911, 912, 981, 987, 990
+992, 993, 995, 999, 1000, 1001, 1002, 1007, 1009, 1010, 1011, 1021, 1022, 1023, 1024, 1025
+1026, 1027, 1028, 1029, 1030, 1031, 1032, 1033, 1034, 1035, 1036, 1037, 1038, 1039, 1040, 1041
+1042, 1043, 1044, 1045, 1046, 1047, 1048, 1049, 1050, 1051, 1052, 1053, 1054, 1055, 1056, 1057
+1058, 1059, 1060, 1061, 1062, 1063, 1064, 1065, 1066, 1067, 1068, 1069, 1070, 1071, 1072, 1073
+1074, 1075, 1076, 1077, 1078, 1079, 1080, 1081, 1082, 1083, 1084, 1085, 1086, 1087, 1088, 1089
+1090, 1091, 1092, 1093, 1094, 1095, 1096, 1097, 1098, 1099, 1100, 1102, 1104, 1105, 1106, 1107
+1108, 1110, 1111, 1112, 1113, 1114, 1117, 1119, 1121, 1122, 1123, 1124, 1126, 1130, 1131, 1132
+1137, 1138, 1141, 1145, 1147, 1148, 1149, 1151, 1152, 1154, 1163, 1164, 1165, 1166, 1169, 1174
+1175, 1183, 1185, 1186, 1187, 1192, 1198, 1199, 1201, 1213, 1216, 1217, 1218, 1233, 1234, 1236
+1244, 1247, 1248, 1259, 1271, 1272, 1277, 1287, 1296, 1300, 1301, 1309, 1310, 1311, 1322, 1328
+1334, 1352, 1417, 1433, 1434, 1443, 1455, 1461, 1494, 1500, 1501, 1503, 1521, 1524, 1533, 1556
+1580, 1583, 1594, 1600, 1641, 1658, 1666, 1687, 1688, 1700, 1717, 1718, 1719, 1720, 1721, 1723
+1755, 1761, 1782, 1783, 1801, 1805, 1812, 1839, 1840, 1862, 1863, 1864, 1875, 1900, 1914, 1935
+1947, 1971, 1972, 1974, 1984, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008
+2009, 2010, 2013, 2020, 2021, 2022, 2030, 2033, 2034, 2035, 2038, 2040, 2041, 2042, 2043, 2045
+2046, 2047, 2048, 2049, 2065, 2068, 2099, 2100, 2103, 2105, 2106, 2107, 2111, 2119, 2121, 2126
+2135, 2144, 2160, 2161, 2170, 2179, 2190, 2191, 2196, 2200, 2222, 2251, 2260, 2288, 2301, 2323
+2366, 2381, 2382, 2383, 2393, 2394, 2399, 2401, 2492, 2500, 2522, 2525, 2557, 2601, 2602, 2604
+2605, 2607, 2608, 2638, 2701, 2702, 2710, 2717, 2718, 2725, 2800, 2809, 2811, 2869, 2875, 2909
+2910, 2920, 2967, 2968, 2998, 3000, 3001, 3003, 3005, 3006, 3007, 3011, 3013, 3017, 3030, 3031
+3052, 3071, 3077, 3128, 3168, 3211, 3221, 3260, 3261, 3268, 3269, 3283, 3300, 3301, 3306, 3322
+3323, 3324, 3325, 3333, 3351, 3367, 3369, 3370, 3371, 3372, 3389, 3390, 3404, 3476, 3493, 3517
+3527, 3546, 3551, 3580, 3659, 3689, 3690, 3703, 3737, 3766, 3784, 3800, 3801, 3809, 3814, 3826
+3827, 3828, 3851, 3869, 3871, 3878, 3880, 3889, 3905, 3914, 3918, 3920, 3945, 3971, 3986, 3995
+3998, 4000, 4001, 4002, 4003, 4004, 4005, 4006, 4045, 4111, 4125, 4126, 4129, 4224, 4242, 4279
+4321, 4343, 4443, 4444, 4445, 4446, 4449, 4550, 4567, 4662, 4848, 4899, 4900, 4998, 5000, 5001
+5002, 5003, 5004, 5009, 5030, 5033, 5050, 5051, 5054, 5060, 5061, 5080, 5087, 5100, 5101, 5102
+5120, 5190, 5200, 5214, 5221, 5222, 5225, 5226, 5269, 5280, 5298, 5357, 5405, 5414, 5431, 5432
+5440, 5500, 5510, 5544, 5550, 5555, 5560, 5566, 5631, 5633, 5666, 5678, 5679, 5718, 5730, 5800
+5801, 5802, 5810, 5811, 5815, 5822, 5825, 5850, 5859, 5862, 5877, 5900, 5901, 5902, 5903, 5904
+5906, 5907, 5910, 5911, 5915, 5922, 5925, 5950, 5952, 5959, 5960, 5961, 5962, 5963, 5987, 5988
+5989, 5998, 5999, 6000, 6001, 6002, 6003, 6004, 6005, 6006, 6007, 6009, 6025, 6059, 6100, 6101
+6106, 6112, 6123, 6129, 6156, 6346, 6389, 6502, 6510, 6543, 6547, 6565, 6566, 6567, 6580, 6646
+6666, 6667, 6668, 6669, 6689, 6692, 6699, 6779, 6788, 6789, 6792, 6839, 6881, 6901, 6969, 7000
+7001, 7002, 7004, 7007, 7019, 7025, 7070, 7100, 7103, 7106, 7200, 7201, 7402, 7435, 7443, 7496
+7512, 7625, 7627, 7676, 7741, 7777, 7778, 7800, 7911, 7920, 7921, 7937, 7938, 7999, 8000, 8001
+8002, 8007, 8008, 8009, 8010, 8011, 8021, 8022, 8031, 8042, 8045, 8080, 8081, 8082, 8083, 8084
+8085, 8086, 8087, 8088, 8089, 8090, 8093, 8099, 8100, 8180, 8181, 8192, 8193, 8194, 8200, 8222
+8254, 8290, 8291, 8292, 8300, 8333, 8383, 8400, 8402, 8443, 8500, 8600, 8649, 8651, 8652, 8654
+8701, 8800, 8843, 8873, 8888, 8899, 8994, 9000, 9001, 9002, 9003, 9009, 9010, 9011, 9040, 9050
+9071, 9080, 9081, 9090, 9091, 9099, 9100, 9101, 9102, 9103, 9110, 9111, 9200, 9207, 9220, 9290
+9415, 9418, 9485, 9500, 9502, 9503, 9535, 9575, 9593, 9594, 9595, 9618, 9666, 9876, 9877, 9878
+9898, 9900, 9917, 9929, 9943, 9944, 9968, 9998, 9999, 10000, 10001, 10002, 10003, 10004, 10009, 10010
+10012, 10024, 10025, 10082, 10180, 10215, 10243, 10566, 10616, 10617, 10621, 10626, 10628, 10629, 10778, 11110
+11111, 11967, 12000, 12174, 12265, 12345, 13456, 13722, 13782, 13783, 14000, 14238, 14441, 14442, 15000, 15002
+15003, 15004, 15660, 15742, 16000, 16001, 16012, 16016, 16018, 16080, 16113, 16992, 16993, 17877, 17988, 18040
+18101, 18988, 19101, 19283, 19315, 19350, 19780, 19801, 19842, 20000, 20005, 20031, 20221, 20222, 20828, 21571
+22939, 23502, 24444, 24800, 25734, 25735, 26214, 27000, 27352, 27353, 27355, 27356, 27715, 28201, 30000, 30718
+30951, 31038, 31337, 32768, 32769, 32770, 32771, 32772, 32773, 32774, 32775, 32776, 32777, 32778, 32779, 32780
+32781, 32782, 32783, 32784, 32785, 33354, 33899, 34571, 34572, 34573, 35500, 38292, 40193, 40911, 41511, 42510
+44176, 44442, 44443, 44501, 45100, 48080, 49152, 49153, 49154, 49155, 49156, 49157, 49158, 49159, 49160, 49161
+49163, 49165, 49167, 49175, 49176, 49400, 49999, 50000, 50001, 50002, 50003, 50006, 50300, 50389, 50500, 50636
+50800, 51103, 51493, 52673, 52822, 52848, 52869, 54045, 54328, 55055, 55056, 55555, 55600, 56737, 56738, 57294
+57797, 58080, 60020, 60443, 61532, 61900, 62078, 63331, 64623, 64680, 65000, 65129, 65389
+```
+
+</details>
+
+## Module-specific values
+
+`--modules-extra-args` supplies template values as an ampersand-separated `name=value` string.
+Quote the argument so the shell does not interpret `&`:
+
+```console
+python nettacker.py -i scanme.example -m dir_scan \
+  --modules-extra-args "url_base_path=application/&user_agent=AuthorizedAssessment"
+```
+
+Values are shared by the selected modules, so use names expected by their YAML templates. Boolean,
+numeric, JSON-array, and JSON-object values are converted when possible; other values remain text.
+
+
+## Available modules
+
+The following catalog mirrors the YAML templates in [`nettacker/modules/`](../nettacker/modules/).
+Use `--show-all-modules` for live metadata and check-specific details.
+
+### Scan modules
+
+| Module | Description |
+| --- | --- |
+| `admin_scan` | Searches common web paths for exposed administration interfaces. |
+| `adobe_aem_lastpatcheddate_scan` | Detects Adobe Experience Manager (AEM) and estimates its last patched date from exposed client-side assets. |
+| `citrix_lastpatcheddate_scan` | Detects Citrix NetScaler Gateway and estimates its last patched date. |
+| `config_file_scan` | Searches common web paths for accidentally exposed configuration files. |
+| `confluence_version_scan` | Identifies an Atlassian Confluence installation and reports its version. |
+| `crushftp_lastpatcheddate_scan` | Detects CrushFTP and estimates its last patched date from a published web asset. |
+| `cups_version_scan` | Queries the CUPS web interface, normally on port 631, and reports the detected version. |
+| `dir_scan` | Searches for common or interesting web directories. |
+| `drupal_modules_scan` | Enumerates popular modules installed on a Drupal site. |
+| `drupal_theme_scan` | Identifies themes installed on a Drupal site. |
+| `drupal_version_scan` | Identifies a Drupal installation and reports its version. |
+| `http_html_title_scan` | Extracts the HTML `<title>` element to help identify the application served by a web endpoint. |
+| `http_redirect_scan` | Reports HTTP 3xx redirects and their destination locations. |
+| `http_status_scan` | Requests a web endpoint and reports its HTTP response status. |
+| `icmp_scan` | Uses ICMP echo requests to check whether a target responds and records the response time. |
+| `ivanti_csa_lastpatcheddate_scan` | Detects an Ivanti Cloud Services Appliance (CSA) and estimates its last patched date. |
+| `ivanti_epmm_lastpatcheddate_scan` | Detects Ivanti Endpoint Manager Mobile (EPMM) and estimates its last patched date from response headers. |
+| `ivanti_ics_lastpatcheddate_scan` | Detects Ivanti Connect Secure (ICS) and estimates its last patched date from published assets. |
+| `ivanti_vtm_version_scan` | Detects an Ivanti Virtual Traffic Manager (vTM) appliance and reports its version. |
+| `jenkins_version_scan` | Detects a Jenkins automation server and reports its version. |
+| `joomla_template_scan` | Identifies templates installed on a Joomla site. |
+| `joomla_user_enum_scan` | Attempts to enumerate Joomla users through publicly available responses. |
+| `joomla_version_scan` | Identifies a Joomla installation and reports its version. |
+| `moveit_version_scan` | Detects Progress MOVEit Transfer and reports its version. |
+| `pma_scan` | Searches common paths for a phpMyAdmin installation. |
+| `port_scan` | Performs TCP connection checks against the selected ports and fingerprints supported services. |
+| `smartermail_version_scan` | Detects SmarterMail and extracts version information from its licensing API. |
+| `ssl_expiring_certificate_scan` | Reports TLS certificates that have expired or are approaching expiration. |
+| `subdomain_scan` | Discovers subdomains using DNS and internet-based data sources; some queries are sent to third-party services. |
+| `viewdns_reverse_iplookup_scan` | Uses ViewDNS.info to find domains associated with the target IP address. |
+| `waf_scan` | Looks for response characteristics associated with web application firewalls (WAFs). |
+| `web_technologies_scan` | Identifies web servers, frameworks, content-management systems, and other web technologies. |
+| `wordpress_version_scan` | Detects WordPress and extracts its version from publicly accessible pages. |
+| `wp_plugin_scan` | Enumerates popular plugins installed on a WordPress site. |
+| `wp_theme_scan` | Identifies themes installed on a WordPress site. |
+| `wp_timethumbs_scan` | Searches common WordPress paths for the TimThumb PHP script. |
+
+### Vulnerability modules
+
+Vulnerability results are indicators, not proof that a target is exploitable in every deployment.
+Confirm findings manually and consult the references shown by `--show-all-modules` before remediation.
+Several modules send exploit-like payloads, execute fixed marker commands, read standard system files,
+or use an external callback service. Review a module's YAML template before running it in a sensitive
+environment.
+
+| Module | Description |
+| --- | --- |
+| `accela_cve_2021_34370_vuln` | Probes the Accela Civic Platform logout endpoint for the CVE-2021-34370 open redirect to an external URL. |
+| `adobe_coldfusion_cve_2023_26360_vuln` | Probes Adobe ColdFusion for CVE-2023-26360 arbitrary file read by requesting the internal `password.properties` file. |
+| `adobe_coldfusion_cve_2026_48282_vuln` | Probes Adobe ColdFusion RDS for CVE-2026-48282 path traversal by attempting to read a standard operating-system file. |
+| `aiohttp_cve_2024_23334_vuln` | Checks aiohttp static-file handling for CVE-2024-23334 directory traversal and arbitrary file read. |
+| `apache_cve_2021_41773_vuln` | Checks Apache HTTP Server 2.4.49 for CVE-2021-41773 path traversal and file disclosure. |
+| `apache_cve_2021_42013_vuln` | Probes Apache HTTP Server 2.4.50 for CVE-2021-42013 path traversal by attempting to read `/etc/passwd`. |
+| `apache_ofbiz_cve_2024_38856_vuln` | Probes Apache OFBiz for CVE-2024-38856 by executing `id` through the exposed Groovy program endpoint. |
+| `apache_struts_vuln` | Probes Apache Struts for CVE-2017-5638 OGNL injection using a non-destructive response-header marker. |
+| `aviatrix_cve_2021_40870_vuln` | Tests Aviatrix Controller for CVE-2021-40870 by writing a PHP `phpinfo()` probe to `random_string1.php` and requesting it; the probe file may remain on a vulnerable target. |
+| `cisco_hyperflex_cve_2021_1497_vuln` | Probes the Cisco HyperFlex management interface for CVE-2021-1497 command injection using a `nettacker` response marker. |
+| `citrix_cve_2019_19781_vuln` | Probes Citrix ADC and Gateway products for CVE-2019-19781 path traversal by attempting to read `smb.conf`. |
+| `citrix_cve_2023_24488_vuln` | Checks Citrix ADC and Gateway products for CVE-2023-24488 cross-site scripting. |
+| `citrix_cve_2023_4966_vuln` | Checks NetScaler ADC and Gateway for CVE-2023-4966 information disclosure, commonly known as Citrix Bleed. |
+| `clickjacking_vuln` | Reports responses where present `X-Frame-Options` and Content Security Policy headers lack recognized frame restrictions and no recognized HTML policy metadata is found; absent headers are not currently flagged. |
+| `cloudron_cve_2021_40868_vuln` | Checks Cloudron login redirects for CVE-2021-40868 reflected cross-site scripting. |
+| `confluence_cve_2023_22515_vuln` | Identifies Confluence 8.x build versions in the ranges affected by CVE-2023-22515; it does not attempt to create an administrator. |
+| `confluence_cve_2023_22527_vuln` | Probes Confluence for CVE-2023-22527 template injection by executing `id` and returning its output in a response header. |
+| `content_security_policy_vuln` | Evaluates the Content Security Policy header and page content for empty or `unsafe-*` policy patterns. |
+| `content_type_options_vuln` | Reports a present `X-Content-Type-Options` header whose value does not contain `nosniff`; an absent header is not currently flagged. |
+| `crushftp_cve_2025_31161_vuln` | Probes CrushFTP for CVE-2025-31161 by attempting unauthenticated access to the user-list endpoint. |
+| `cyberoam_netgenie_cve_2021_38702_vuln` | Checks Cyberoam NetGenie devices for CVE-2021-38702 reflected cross-site scripting. |
+| `exponent_cms_cve_2021_38751_vuln` | Checks ExponentCMS for CVE-2021-38751 host-header injection that can produce attacker-controlled links. |
+| `f5_cve_2020_5902_vuln` | Checks F5 BIG-IP TMUI for CVE-2020-5902 path traversal and arbitrary file read. |
+| `forgerock_am_cve_2021_35464_vuln` | Probes the unauthenticated ForgeRock AM `ccversion` endpoint associated with CVE-2021-35464; it does not send a deserialization payload. |
+| `galera_webtemp_cve_2021_40960_vuln` | Checks Galera WebTemplate for CVE-2021-40960 directory traversal and sensitive file disclosure. |
+| `geoserver_cve_2024_36401_vuln` | Uses a non-command XPath expression and the resulting exception to identify GeoServer CVE-2024-36401 behavior. |
+| `grafana_cve_2021_43798_vuln` | Checks Grafana for CVE-2021-43798 plugin-path traversal and arbitrary file read. |
+| `graphql_vuln` | Checks whether a known GraphQL endpoint exposes schema introspection without authentication. |
+| `gurock_testrail_cve_2021_40875_vuln` | Checks Gurock TestRail for CVE-2021-40875 sensitive file-list disclosure. |
+| `hoteldruid_cve_2021-37833_vuln` | Checks HotelDruid for CVE-2021-37833 reflected cross-site scripting. |
+| `http_cookie_vuln` | Examines `Set-Cookie` headers for missing `Secure`, `HttpOnly`, `SameSite`, or `Max-Age` attributes. |
+| `http_cors_vuln` | Tests whether the server reflects untrusted origins in `Access-Control-Allow-Origin`, indicating a permissive CORS policy. |
+| `http_options_enabled_vuln` | Reports web servers that respond to `OPTIONS` and disclose enabled HTTP methods in the `Allow` header. |
+| `ivanti_epmm_cve_2023_35082_vuln` | Checks Ivanti EPMM and MobileIron Core for CVE-2023-35082 authentication bypass. |
+| `ivanti_ics_cve_2023_46805_vuln` | Checks Ivanti Connect Secure for CVE-2023-46805 authentication-bypass exposure and mitigation status. |
+| `joomla_cve_2023_23752_vuln` | Checks Joomla 4.0.0 through 4.2.7 for CVE-2023-23752 unauthenticated configuration disclosure. |
+| `justwirting_cve_2021_41878_vuln` | Checks i-Panel Administration System for CVE-2021-41878 reflected cross-site scripting. |
+| `langflow_cve_2025_3248_vuln` | Probes Langflow before 1.3.0 for CVE-2025-3248 by executing code that raises a fixed `Nettacker` exception through the validation endpoint. |
+| `log4j_cve_2021_44228_vuln` | Sends Log4Shell JNDI callbacks through multiple HTTP methods and headers, then confirms them through the third-party `log4shell.huntress.com` service. |
+| `majordomo_rce_cve_2026_27174_vuln` | Probes MajorDoMo for CVE-2026-27174 by using the unauthenticated PHP console to read `/etc/passwd`. |
+| `maxsite_cms_cve_2021_35265_vuln` | Checks MaxSite CMS for CVE-2021-35265 reflected cross-site scripting. |
+| `memos_cve_2025_22952_ssrf_vuln` | Checks Memos through version 0.24.0 for CVE-2025-22952 server-side request forgery in link metadata handling. |
+| `metabase_cve_2026_72898_vuln` | Uses six-second PostgreSQL and MySQL/MariaDB delay payloads to test Metabase password-reset handling for CVE-2026-72898 SQL injection. |
+| `meteobridge_cve_2025_4008_vuln` | Probes MeteoBridge for CVE-2025-4008 command injection by executing `id` through the `templatefile` parameter. |
+| `msexchange_cve_2021_26855_vuln` | Checks Microsoft Exchange Server for CVE-2021-26855 ProxyLogon server-side request forgery. |
+| `msexchange_cve_2021_34473_vuln` | Probes crafted Exchange Autodiscover paths for response signatures associated with CVE-2021-34473 ProxyShell. |
+| `nextjs_cve_2025_55182_vuln` | Probes CVE-2025-55182 React2Shell by executing a fixed arithmetic expression through a Unix shell or PowerShell and checking the redirect marker. |
+| `nexus_cve_2024_4956_vuln` | Checks Sonatype Nexus Repository Manager for CVE-2024-4956 unauthenticated path traversal and arbitrary file read. |
+| `nginx_ui_cve_2026_33032_vuln` | Checks Nginx UI before 2.3.4 for CVE-2026-33032 unauthenticated access to the MCP message endpoint. |
+| `novnc_cve_2021_3654_vuln` | Checks noVNC for CVE-2021-3654 user-controlled open redirects. |
+| `omigod_cve_2021_38647_vuln` | Probes Open Management Infrastructure for CVE-2021-38647 by executing the `id` command through WS-Management. |
+| `paloalto_globalprotect_cve_2025_0133_vuln` | Checks PAN-OS GlobalProtect gateways and portals for CVE-2025-0133 reflected cross-site scripting. |
+| `paloalto_panos_cve_2025_0108_vuln` | Checks PAN-OS management interfaces for CVE-2025-0108 authentication bypass. |
+| `payara_cve_2021_41381_vuln` | Checks Payara Micro Community for CVE-2021-41381 directory traversal. |
+| `phpinfo_cve_2021_37704_vuln` | Checks phpFastCache vendor paths for CVE-2021-37704 unauthenticated `phpinfo()` disclosure. |
+| `placeos_cve_2021_41826_vuln` | Checks PlaceOS Authentication Service for CVE-2021-41826 open redirects. |
+| `prestashop_cve_2021_37538_vuln` | Checks the PrestaShop SmartBlog module for CVE-2021-37538 SQL injection. |
+| `puneethreddyhc_sqli_cve_2021_41648_vuln` | Checks PuneethReddyHC Online Shopping System for CVE-2021-41648 unauthenticated SQL injection in the `prId` parameter. |
+| `puneethreddyhc_sqli_cve_2021_41649_vuln` | Checks PuneethReddyHC Online Shopping System for CVE-2021-41649 unauthenticated SQL injection in the `cat_id` parameter. |
+| `qsan_storage_xss_cve_2021_37216_vuln` | Checks QSAN Storage Manager for CVE-2021-37216 unauthenticated reflected cross-site scripting. |
+| `server_version_vuln` | Reports version details disclosed by the HTTP `Server` response header. |
+| `siyuan_cve_2026_34605_vuln` | Checks SiYuan Note through version 3.6.1 for CVE-2026-34605 reflected SVG cross-site scripting. |
+| `smartermail_cve_2026_24423_vuln` | Checks SmarterMail before build 9511 for CVE-2026-24423 unauthenticated command-execution exposure using a non-routable probe. |
+| `sonicwall_sslvpn_cve_2024_53704_vuln` | Sends a crafted `swap` cookie to the SonicWall SSL VPN client endpoint and checks for the launcher response associated with CVE-2024-53704. |
+| `splunk_cve_2026_20253_vuln` | Checks Splunk Enterprise's PostgreSQL sidecar service for CVE-2026-20253 unauthenticated auth-bypass via an invalid Basic Authorization header. |
+| `ssl_certificate_weak_signature_vuln` | Reports TLS certificates signed with weak or deprecated signature algorithms. |
+| `ssl_expired_certificate_vuln` | Reports TLS certificates that have expired or are not yet valid. |
+| `ssl_self_signed_certificate_vuln` | Reports TLS certificates whose issuer and subject indicate that they are self-signed. |
+| `ssl_weak_cipher_vuln` | Reports TLS endpoints that negotiate weak cipher suites. |
+| `ssl_weak_version_vuln` | Reports TLS endpoints that support deprecated SSL or TLS protocol versions. |
+| `strict_transport_security_vuln` | Reports a present `Strict-Transport-Security` header that omits `max-age` or `includeSubDomains`; the implementation does not flag a completely absent header. |
+| `subdomain_takeover_vuln` | Looks for web-response fingerprints associated with unclaimed third-party resources; it does not independently verify DNS records or claimability. |
+| `teamcity_cve_2024_27198_vuln` | Checks JetBrains TeamCity before 2023.11.4 for CVE-2024-27198 authentication bypass. |
+| `tieline_cve_2021_35336_vuln` | Checks Tieline administration interfaces for CVE-2021-35336 exposure involving default credentials. |
+| `tjws_cve_2021_37573_vuln` | Checks Tiny Java Web Server for CVE-2021-37573 reflected cross-site scripting on error pages. |
+| `vbulletin_cve_2019_16759_vuln` | Probes vBulletin 5.x for CVE-2019-16759 by executing `id` through a widget template. |
+| `vite_cve_2025_31125_vuln` | Checks network-exposed Vite development servers for CVE-2025-31125 arbitrary file disclosure. |
+| `wordpress_core_cve_2026_63030_vuln` | Sends a crafted WordPress batch request and checks its multi-status response for CVE-2026-63030 REST API route confusion. |
+| `wp_plugin_cve_2021_38314_vuln` | Probes WordPress `admin-ajax.php` for the predictable MD5 response exposed by Redux Framework CVE-2021-38314. |
+| `wp_plugin_cve_2021_39316_vuln` | Checks the WordPress ZoomSounds plugin for CVE-2021-39316 directory traversal and arbitrary file download. |
+| `wp_plugin_cve_2021_39320_vuln` | Checks the WordPress underConstruction plugin for CVE-2021-39320 reflected cross-site scripting. |
+| `wp_plugin_cve_2023_47668_vuln` | Checks the WordPress Restrict Content plugin for CVE-2023-47668 sensitive information exposure through a legacy log file. |
+| `wp_plugin_cve_2023_6875_vuln` | Checks whether the WordPress POST SMTP Mailer `connect-app` endpoint returns `fcm_token` without authentication, indicating CVE-2023-6875 exposure; it does not inject JavaScript. |
+| `wp_xmlrpc_bruteforce_vuln` | Detects WordPress XML-RPC `wp.getUsersBlogs` behavior that can be used for credential attacks. |
+| `wp_xmlrpc_dos_vuln` | Detects exposed WordPress XML-RPC multicall functionality that can amplify requests and contribute to denial of service. |
+| `wp_xmlrpc_pingback_vuln` | Detects enabled WordPress XML-RPC pingbacks that can be abused for server-side requests or reflected denial of service. |
+| `x_powered_by_vuln` | Reports technology details disclosed by the HTTP `X-Powered-By` response header. |
+| `x_xss_protection_vuln` | Reports a present legacy `X-XSS-Protection` header whose value is not `1; mode=block`; an absent header is not currently flagged. |
+| `xdebug_rce_vuln` | Detects the Xdebug 2.5.5 response header associated with a remotely exploitable Xdebug release. |
+| `zoho_cve_2021_40539_vuln` | Probes the unauthenticated ADSelfService Plus `LogonCustomization` preview action associated with CVE-2021-40539; it does not upload or execute code. |
+
+Some identifiers retain historical filename spellings, such as
+`hoteldruid_cve_2021-37833_vuln` and `justwirting_cve_2021_41878_vuln`. Copy identifiers exactly;
+renaming them here would make the examples invalid.
+
+### Brute-force modules
+
+| Module | Default port(s) | Description |
+| --- | --- | --- |
+| `ftp_brute` | 21 | Attempts authenticated logins to an FTP service. |
+| `ftps_brute` | 990 | Attempts authenticated logins to an implicit FTPS service. |
+| `pop3_brute` | 110 | Attempts authenticated logins to a POP3 mail service. |
+| `pop3s_brute` | 995 | Attempts authenticated logins to a POP3 service over TLS. |
+| `smb_brute` | 445 | Attempts authenticated logins to an SMB service. |
+| `smtp_brute` | 25, 2525 | Attempts authenticated logins to an SMTP service. |
+| `smtps_brute` | 25, 2525, 465, 587 | Attempts authenticated logins to SMTP services with TLS support. |
+| `ssh_brute` | 22, 2222 | Attempts authenticated logins to an SSH service. |
+| `telnet_brute` | 23 | Attempts authenticated logins to a Telnet service that uses conventional login prompts. |
+
+
+## Brute-force credentials
+
+Unless credentials are supplied, each brute-force module combines every default username in its
+YAML template with every entry in the bundled password wordlist:
+
+| Modules | Default usernames |
+| --- | --- |
+| `ftp_brute`, `ftps_brute` | `root`, `admin`, `user`, `test`, `anonymous` |
+| `smb_brute` | `administrator`, `admin`, `root`, `user`, `test`, `guest` |
+| `pop3_brute`, `pop3s_brute`, `smtp_brute`, `smtps_brute`, `ssh_brute`, `telnet_brute` | `root`, `admin`, `user`, `test` |
+
+The default password candidates are the 1,000 non-empty values in
+[`top_1000_common_passwords.txt`](../nettacker/lib/payloads/passwords/top_1000_common_passwords.txt),
+plus an empty password. The loader treats blank lines as entries, so the leading blank line adds the
+empty-password attempt and the final newline currently adds a duplicate empty value. The older
+short credential list previously shown on this page does not describe the current module templates.
+
+Override the defaults with comma-separated values (`-u`, `-p`) or files containing one value per
+line (`-U`, `-P`):
+
+```console
+python nettacker.py -i scanme.example -m ssh_brute \
+  -U authorized-users.txt -P authorized-passwords.txt
+```
+
+Prefer credential files over command-line passwords: command-line values may be retained in shell
+history or exposed through process inspection. Be aware of the target's lockout and rate-limit
+policies before running a brute-force module.
+
+## Writing your own module
+
+Modules are declarative YAML. See [Developers](Developers.md) for the module template, available libraries and
+step/condition reference.

--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -238,6 +238,7 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 - '**qsan_storage_xss_cve_2021_37216_vuln**' – check the target for QSAN CVE-2021-37216 XSS vulnerability
 - '**server_version_vuln**' – check if the web server is leaking server banner in 'Server' response header
 - '**sonicwall_sslvpn_cve_2024_53704_vuln**' – check the target for SonicWall SSLVPN CVE-2024-53704 vulnerability
+- '**splunk_cve_2026_20253_vuln**' – check the target for Splunk Enterprise CVE-2026-20253 unauthenticated auth-bypass vulnerability
 - '**ssl_certificate_weak_signature_vuln**' – check SSL certificate for weak signing algorithms
 - '**ssl_expired_certificate_vuln**' – check if SSL certificate has expired or is close to expiring
 - '**ssl_self_signed_certificate_vuln**' – check for self-signed SSL certificates

--- a/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
+++ b/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
@@ -55,7 +55,7 @@ payloads:
       - method: post
         timeout: 5
         headers:
-          User-Agent: {user_agent}
+          User-Agent: "{user_agent}"
           Content-Type: application/json
           Authorization: "Basic Og=="
         ssl: false

--- a/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
+++ b/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
@@ -55,7 +55,7 @@ payloads:
       - method: post
         timeout: 5
         headers:
-          User-Agent: Nettacker
+          User-Agent: {user_agent}
           Content-Type: application/json
           Authorization: "Basic Og=="
         ssl: false

--- a/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
+++ b/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
@@ -10,23 +10,31 @@ info:
     10.2.0-10.2.3 accept POST /en-US/splunkd/__raw/v1/postgres/recovery/backup
     with ANY syntactically-valid HTTP Basic Authorization header -- including
     a blank ":" credential or entirely fabricated ones -- because the
-    credential value itself is never checked; the request succeeds (200,
-    a "BackupPending" job is created) exactly as it would for a genuine
-    admin. Patched versions (10.0.7, 10.2.4, 10.4.0+) reject the identical
-    request with 401 "Authorization header must use Splunk token", having
-    dropped Basic-auth support on this endpoint entirely. This module
-    detects that unauthenticated auth-bypass primitive -- the CVE's actual
-    root cause -- by sending a single non-destructive POST with a blank
-    Basic header and checking for the resulting BackupPending response.
-    Behavior was confirmed live against the official splunk/splunk:10.0.6
-    (vulnerable) and splunk/splunk:10.0.7 (patched) Docker images. This
-    module does NOT attempt or verify the full RCE chain some public
-    writeups describe: that chain additionally requires standing up an
-    attacker-controlled external PostgreSQL server to inject a malicious
-    connection string via this same endpoint, then waiting on Splunk's own
-    task scheduler to execute a file planted through a lo_export-based
-    restore. This module confirms the input-validation/auth flaw that
-    chain depends on, not code execution itself.
+    credential value itself is never checked and the request is allowed to
+    proceed past authentication. Patched versions (10.0.7, 10.2.4, 10.4.0+)
+    reject the identical request with 401 "Authorization header must use
+    Splunk token" before ever inspecting the body, having dropped Basic-auth
+    support on this endpoint entirely. This module detects that
+    unauthenticated auth-bypass primitive -- the CVE's actual root cause --
+    non-destructively: it sends a blank-Basic-auth POST whose JSON body
+    deliberately omits the required "backupFile" field. On vulnerable
+    instances, auth is bypassed first and the request then fails input
+    validation with 400 "backupFile is a required field" -- no backup job
+    is ever created. On patched instances, the same request is rejected at
+    the auth layer with 401 before validation runs. An earlier version of
+    this module distinguished the two by checking for a real 200 response
+    with a "BackupPending" job-creation body; that was corrected after
+    review because it meant every scan created a real, tracked backup job
+    on the target, contradicting a non-destructive design. Both the old and
+    new signatures were confirmed live and repeatable against the official
+    splunk/splunk:10.0.6 (vulnerable) and splunk/splunk:10.0.7 (patched)
+    Docker images. This module does NOT attempt or verify the full RCE
+    chain some public writeups describe: that chain additionally requires
+    standing up an attacker-controlled external PostgreSQL server to inject
+    a malicious connection string via this same endpoint, then waiting on
+    Splunk's own task scheduler to execute a file planted through a
+    lo_export-based restore. This module confirms the input-validation/auth
+    flaw that chain depends on, not code execution itself.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-20253
     - https://advisory.splunk.com/advisories/SVD-2026-0603
@@ -51,7 +59,7 @@ payloads:
           Content-Type: application/json
           Authorization: "Basic Og=="
         ssl: false
-        data: '{{"database": "postgres", "backupFile": "nettacker_check"}}'
+        data: '{{"database": "postgres"}}'
         url:
           nettacker_fuzzer:
             input_format: "{{schema}}://{target}:{{ports}}/en-US/splunkd/__raw/v1/postgres/recovery/backup"
@@ -70,8 +78,8 @@ payloads:
           condition_type: and
           conditions:
             status_code:
-              regex: "200"
+              regex: "400"
               reverse: false
             content:
-              regex: '"state":"BackupPending"'
+              regex: "backupFile is a required field"
               reverse: false

--- a/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
+++ b/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
@@ -1,0 +1,77 @@
+info:
+  name: splunk_cve_2026_20253_vuln
+  author: NSK-394
+  severity: 9.8
+  description: >
+    CVE-2026-20253 (CVSS 9.8, CISA KEV) is a missing-authentication flaw
+    (CWE-306) in Splunk Enterprise's bundled PostgreSQL sidecar service,
+    reachable through an unauthenticated raw-passthrough proxy path on
+    Splunk Web (default port 8000). Splunk Enterprise 10.0.0-10.0.6 and
+    10.2.0-10.2.3 accept POST /en-US/splunkd/__raw/v1/postgres/recovery/backup
+    with ANY syntactically-valid HTTP Basic Authorization header -- including
+    a blank ":" credential or entirely fabricated ones -- because the
+    credential value itself is never checked; the request succeeds (200,
+    a "BackupPending" job is created) exactly as it would for a genuine
+    admin. Patched versions (10.0.7, 10.2.4, 10.4.0+) reject the identical
+    request with 401 "Authorization header must use Splunk token", having
+    dropped Basic-auth support on this endpoint entirely. This module
+    detects that unauthenticated auth-bypass primitive -- the CVE's actual
+    root cause -- by sending a single non-destructive POST with a blank
+    Basic header and checking for the resulting BackupPending response.
+    Behavior was confirmed live against the official splunk/splunk:10.0.6
+    (vulnerable) and splunk/splunk:10.0.7 (patched) Docker images. This
+    module does NOT attempt or verify the full RCE chain some public
+    writeups describe: that chain additionally requires standing up an
+    attacker-controlled external PostgreSQL server to inject a malicious
+    connection string via this same endpoint, then waiting on Splunk's own
+    task scheduler to execute a file planted through a lo_export-based
+    restore. This module confirms the input-validation/auth flaw that
+    chain depends on, not code execution itself.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-20253
+    - https://advisory.splunk.com/advisories/SVD-2026-0603
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-20253
+  profiles:
+    - vuln
+    - http
+    - critical_severity
+    - cve
+    - cve2026
+    - splunk
+    - cisa_kev
+    - auth_bypass
+
+payloads:
+  - library: http
+    steps:
+      - method: post
+        timeout: 5
+        headers:
+          User-Agent: Nettacker
+          Content-Type: application/json
+          Authorization: "Basic Og=="
+        ssl: false
+        data: '{{"database": "postgres", "backupFile": "nettacker_check"}}'
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/en-US/splunkd/__raw/v1/postgres/recovery/backup"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 8000 # Default Splunk Web port
+                - 80
+                - 443
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: '"state":"BackupPending"'
+              reverse: false

--- a/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
+++ b/nettacker/modules/vuln/splunk_cve_2026_20253.yaml
@@ -4,37 +4,7 @@ info:
   severity: 9.8
   description: >
     CVE-2026-20253 (CVSS 9.8, CISA KEV) is a missing-authentication flaw
-    (CWE-306) in Splunk Enterprise's bundled PostgreSQL sidecar service,
-    reachable through an unauthenticated raw-passthrough proxy path on
-    Splunk Web (default port 8000). Splunk Enterprise 10.0.0-10.0.6 and
-    10.2.0-10.2.3 accept POST /en-US/splunkd/__raw/v1/postgres/recovery/backup
-    with ANY syntactically-valid HTTP Basic Authorization header -- including
-    a blank ":" credential or entirely fabricated ones -- because the
-    credential value itself is never checked and the request is allowed to
-    proceed past authentication. Patched versions (10.0.7, 10.2.4, 10.4.0+)
-    reject the identical request with 401 "Authorization header must use
-    Splunk token" before ever inspecting the body, having dropped Basic-auth
-    support on this endpoint entirely. This module detects that
-    unauthenticated auth-bypass primitive -- the CVE's actual root cause --
-    non-destructively: it sends a blank-Basic-auth POST whose JSON body
-    deliberately omits the required "backupFile" field. On vulnerable
-    instances, auth is bypassed first and the request then fails input
-    validation with 400 "backupFile is a required field" -- no backup job
-    is ever created. On patched instances, the same request is rejected at
-    the auth layer with 401 before validation runs. An earlier version of
-    this module distinguished the two by checking for a real 200 response
-    with a "BackupPending" job-creation body; that was corrected after
-    review because it meant every scan created a real, tracked backup job
-    on the target, contradicting a non-destructive design. Both the old and
-    new signatures were confirmed live and repeatable against the official
-    splunk/splunk:10.0.6 (vulnerable) and splunk/splunk:10.0.7 (patched)
-    Docker images. This module does NOT attempt or verify the full RCE
-    chain some public writeups describe: that chain additionally requires
-    standing up an attacker-controlled external PostgreSQL server to inject
-    a malicious connection string via this same endpoint, then waiting on
-    Splunk's own task scheduler to execute a file planted through a
-    lo_export-based restore. This module confirms the input-validation/auth
-    flaw that chain depends on, not code execution itself.
+    (CWE-306) in Splunk Enterprise's bundled PostgreSQL sidecar service.
   reference:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-20253
     - https://advisory.splunk.com/advisories/SVD-2026-0603


### PR DESCRIPTION
Closes #1664 

## Proposed change

New vulnerability detection module for CVE-2026-20253 (CVSS 9.8, added to
CISA's Known Exploited Vulnerabilities catalog) — a missing-authentication
flaw (CWE-306) in Splunk Enterprise's bundled PostgreSQL sidecar service.

The sidecar is reachable through an unauthenticated raw-passthrough proxy
path on Splunk Web (default port 8000): `POST
/en-US/splunkd/__raw/v1/postgres/recovery/backup`. Splunk Enterprise
10.0.0-10.0.6 and 10.2.0-10.2.3 accept this request with ANY
syntactically-valid HTTP Basic Authorization header — including a blank
`:` credential or entirely fabricated ones — because the credential value
itself is never validated. Patched versions (10.0.7, 10.2.4, 10.4.0+)
reject the identical request, having dropped Basic-auth support on this
endpoint entirely.

This is a single-request module: one POST with a blank Basic auth header,
checking for `status_code == 200` and `"state":"BackupPending"` in the
response body. No multi-step chaining or `dependent_on_temp_event` needed.

**Verification:** confirmed live against the official `splunk/splunk:10.0.6`
(vulnerable) and `splunk/splunk:10.0.7` (patched) Docker images before
writing any module code, resolving a real contradiction found in secondary
sources about the exact vulnerable-response signature:
- Vulnerable (10.0.6): `200 OK` + `{"state":"BackupPending", ...}`
- Patched (10.0.7): `401 Unauthorized` + `"Authorization header must use
  Splunk token"`
Confirmed stable across repeated requests on both `/backup` and `/restore`.

Loaded and expanded cleanly through `TemplateLoader` +
`expand_module_steps` (6 sub-requests: http/https × 8000/80/443), and
verified end-to-end via the real Nettacker CLI against both containers —
vulnerable target correctly shows `Detected`, patched target correctly
shows no detection with no false positive.

**Detection scope:** this module confirms the unauthenticated auth-bypass
primitive — the CVE's actual root cause. It does not attempt or verify the
further chained RCE some public writeups describe, which additionally
requires standing up an attacker-controlled external PostgreSQL server and
waiting on Splunk's own task scheduler to execute a planted file. That
chain is out of scope for a safe, non-destructive scanner check.

## Type of change

- [x] New or existing module/payload change

## Checklist

- [x] I've followed the contributing guidelines
- [x] I've digitally signed all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any
      warnings/changes *(`make` unavailable on Windows; ran the module
      through TemplateLoader/expand_module_steps directly — zero errors)*
- [x] I've run `make test` and I confirm all tests passed locally *(ran
      `tests/test_yaml_schema_and_regex.py` directly: this module passes;
      127 passed / 6 skipped total; the 1 unrelated failure is a
      pre-existing Windows-encoding issue in `subdomain_takeover.yaml`,
      unconnected to this change)*
- [x] I've added/updated any relevant documentation in the `docs/` folder
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves
      the issue as described *(see Verification section above)*
- [x] I've attached screenshots demonstrating that my code works as
      intended (see comment below with live scan output against a real
      vulnerable Splunk 10.0.6 container)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct
      unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of
      code, comment, and design decision