### PR TITLE
fix: stop graph import failures from continuing

### DIFF
--- a/nettacker/core/graph.py
+++ b/nettacker/core/graph.py
@@ -46,6 +46,7 @@ def build_graph(graph_name, events):
         )
     except ModuleNotFoundError:
         die_failure(_("graph_module_unavailable").format(graph_name))
+        return None
 
     log.info(_("finish_build_graph"))
     return start(events)
@@ -67,6 +68,7 @@ def build_compare_report(compare_results):
         )
     except ModuleNotFoundError:
         die_failure(_("graph_module_unavailable").format("compare_report"))
+        return None
 
     log.info(_("finish_build_report"))
     return build_report(compare_results)

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -33,7 +33,6 @@ def test_build_graph_success(mock_import_module):
 
 @patch("nettacker.core.graph.die_failure")
 @patch("nettacker.core.graph.importlib.import_module", side_effect=ModuleNotFoundError)
-@pytest.mark.xfail(reason="It will hit an UnboundLocalError")
 def test_build_graph_module_not_found(mock_import_module, mock_die_failure):
     build_graph("missing_graph", [])
     mock_die_failure.assert_called_once()
@@ -49,7 +48,6 @@ def test_build_compare_report_success(mock_import_module):
 
 @patch("nettacker.core.graph.die_failure")
 @patch("nettacker.core.graph.importlib.import_module", side_effect=ModuleNotFoundError)
-@pytest.mark.xfail(reason="It will hit an UnboundLocalError")
 def test_build_compare_report_module_not_found(mock_import_module, mock_die_failure):
     build_compare_report({"some": "results"})
     mock_die_failure.assert_called_once()


### PR DESCRIPTION
## Summary
- return immediately after `die_failure()` handles missing graph/report modules
- remove xfail markers from the graph import failure tests
- prevents `UnboundLocalError` if `die_failure()` is mocked in tests or otherwise does not terminate execution

## Testing
- ran `python -m compileall nettacker\core\graph.py tests\core\test_graph.py`
- ran `git diff --check`