### PR TITLE
fix: preserve response headers during condition matching

### DIFF
--- a/nettacker/core/lib/http.py
+++ b/nettacker/core/lib/http.py
@@ -54,18 +54,14 @@ def response_conditions_matched(sub_step, response):
             reverse = conditions[condition]["reverse"]
             condition_results[condition] = reverse_and_regex_condition(regex, reverse)
         if condition == "headers":
-            # convert headers to case insensitive dict
-            for key in response["headers"].copy():
-                response["headers"][key.lower()] = response["headers"][key]
+            headers = {key.lower(): value for key, value in response["headers"].items()}
             condition_results["headers"] = {}
             for header in conditions["headers"]:
                 reverse = conditions["headers"][header]["reverse"]
                 try:
                     regex = re.findall(
                         re.compile(conditions["headers"][header]["regex"]),
-                        response["headers"][header.lower()]
-                        if header.lower() in response["headers"]
-                        else False,
+                        headers[header.lower()] if header.lower() in headers else False,
                     )
                     condition_results["headers"][header] = reverse_and_regex_condition(
                         regex, reverse

--- a/tests/core/lib/test_user_added_http_headers.py
+++ b/tests/core/lib/test_user_added_http_headers.py
@@ -290,9 +290,11 @@ def test_response_conditions_headers_case_insensitive():
         "responsetime": 0.05,
         "content": "body",
     }
+    original_headers = response["headers"].copy()
     out = http.response_conditions_matched(sub_step, response)
     assert out != {}
     assert out["headers"]["Content-Type"] == ["text/html"]
+    assert response["headers"] == original_headers
 
 
 def test_response_conditions_responsetime(monkeypatch):


### PR DESCRIPTION
## Summary
- avoid mutating `response["headers"]` while doing case-insensitive header condition matching
- add test coverage that the original response headers remain unchanged

## Testing
- ran `py -3.12 -m compileall nettacker\core\lib\http.py tests\core\lib\test_user_added_http_headers.py`
- ran `git diff --check`