### PR TITLE
refactor: avoid eval in dependent response replacement

### DIFF
--- a/nettacker/core/utils/common.py
+++ b/nettacker/core/utils/common.py
@@ -19,15 +19,14 @@ log = logger.get_logger()
 
 
 def replace_dependent_response(log, response_dependent):
-    """The `response_dependent` is needed for `eval` below."""
     if str(log):
         key_name = re.findall(re.compile("response_dependent\\['\\S+\\]"), log)
         for i in key_name:
-            try:
-                key_value = eval(i)
-            except Exception:
-                key_value = "response dependent error"
-            log = log.replace(i, " ".join(key_value))
+            key = i.removeprefix("response_dependent['").removesuffix("']")
+            key_value = response_dependent.get(key, "response dependent error")
+            if isinstance(key_value, list):
+                key_value = " ".join(key_value)
+            log = log.replace(i, str(key_value))
         return log
 
 

--- a/tests/core/utils/test_common.py
+++ b/tests/core/utils/test_common.py
@@ -135,6 +135,27 @@ def test_merge_logs_to_list_no_shared_state_between_calls():
     assert logs_b == ["second"]
 
 
+def test_replace_dependent_response_uses_key_lookup():
+    response_dependent = {
+        "status_code": ["200"],
+        "__import__('os').system('echo_unsafe')": ["safe"],
+    }
+
+    assert (
+        common_utils.replace_dependent_response(
+            "status response_dependent['status_code']", response_dependent
+        )
+        == "status 200"
+    )
+    assert (
+        common_utils.replace_dependent_response(
+            "expr response_dependent['__import__('os').system('echo_unsafe')']",
+            response_dependent,
+        )
+        == "expr safe"
+    )
+
+
 def test_wait_for_threads_to_finish_all_dead():
     """All threads already finished -- should return True immediately."""
     t = MagicMock(spec=threading.Thread)


### PR DESCRIPTION
## Summary
- replace `eval()` in `replace_dependent_response` with explicit key lookup
- preserve list joining and missing-key fallback behavior
- add regression coverage for dependent response replacements with expression-like keys

## Testing
- `py -3.12 -m compileall nettacker\core\utils\common.py tests\core\utils\test_common.py`
- `git diff --check`
- direct function smoke check with Python 3.12

Note: full pytest was not run because `pytest` is not installed in this environment.