### PR TITLE
refactor: avoid eval for dependent temp event lookup

### DIFF
--- a/nettacker/core/lib/base.py
+++ b/nettacker/core/lib/base.py
@@ -14,6 +14,21 @@ from nettacker.database.db import find_temp_events, submit_logs_to_db, submit_te
 from nettacker.logger import TerminalCodes, get_logger
 
 log = get_logger()
+DEPENDENT_VALUE_RE = re.compile(
+    r"dependent_on_temp_event(?:\[(?:\d+|'[^']+'|\"[^\"]+\")\])+"
+)
+DEPENDENT_VALUE_PART_RE = re.compile(r"\[(\d+|'[^']+'|\"[^\"]+\")\]")
+
+
+def resolve_dependent_value(key_name, dependent_on_temp_event):
+    key_value = dependent_on_temp_event
+    for key_part in DEPENDENT_VALUE_PART_RE.findall(key_name):
+        if key_part.isdigit():
+            key_part = int(key_part)
+        else:
+            key_part = key_part[1:-1]
+        key_value = key_value[key_part]
+    return str(key_value)
 
 
 class BaseLibrary(ABC):
@@ -67,16 +82,12 @@ class BaseEngine(ABC):
                 else:
                     if isinstance(sub_step[key], str):
                         if "dependent_on_temp_event" in sub_step[key]:
-                            globals().update(locals())
                             generate_new_step = copy.deepcopy(sub_step[key])
-                            key_name = re.findall(
-                                re.compile(
-                                    "dependent_on_temp_event\\[\\S+\\]\\['\\S+\\]\\[\\S+\\]"
-                                ),
-                                generate_new_step,
-                            )[0]
+                            key_name = DEPENDENT_VALUE_RE.findall(generate_new_step)[0]
                             try:
-                                key_value = eval(key_name)
+                                key_value = resolve_dependent_value(
+                                    key_name, dependent_on_temp_event
+                                )
                             except Exception:
                                 key_value = "error"
                             sub_step[key] = sub_step[key].replace(key_name, key_value)
@@ -84,20 +95,21 @@ class BaseEngine(ABC):
             value_index = 0
             for key in copy.deepcopy(sub_step):
                 if type(sub_step[value_index]) not in [str, float, int, bytes]:
-                    sub_step[key] = self.find_and_replace_dependent_values(
+                    sub_step[value_index] = self.find_and_replace_dependent_values(
                         copy.deepcopy(sub_step[value_index]), dependent_on_temp_event
                     )
                 else:
                     if isinstance(sub_step[value_index], str):
                         if "dependent_on_temp_event" in sub_step[value_index]:
-                            globals().update(locals())
-                            generate_new_step = copy.deepcopy(sub_step[key])
+                            generate_new_step = copy.deepcopy(sub_step[value_index])
                             key_name = re.findall(
-                                re.compile("dependent_on_temp_event\\['\\S+\\]\\[\\S+\\]"),
+                                DEPENDENT_VALUE_RE,
                                 generate_new_step,
                             )[0]
                             try:
-                                key_value = eval(key_name)
+                                key_value = resolve_dependent_value(
+                                    key_name, dependent_on_temp_event
+                                )
                             except Exception:
                                 key_value = "error"
                             sub_step[value_index] = sub_step[value_index].replace(

--- a/tests/core/lib/test_base_engine.py
+++ b/tests/core/lib/test_base_engine.py
@@ -1,0 +1,38 @@
+from nettacker.core.lib.base import BaseEngine
+
+
+class DummyBaseEngine(BaseEngine):
+    pass
+
+
+def test_find_and_replace_dependent_values_uses_key_lookup():
+    engine = DummyBaseEngine()
+    dependent_on_temp_event = [
+        {
+            "content": ["token"],
+            "headers": {"Set-Cookie": ["session=a", "csrf=b"]},
+        }
+    ]
+    sub_step = {
+        "url": "https://example.test/dependent_on_temp_event[0]['content'][0]",
+        "headers": {
+            "Cookie": "dependent_on_temp_event[0]['headers']['Set-Cookie'][1]",
+        },
+    }
+
+    result = engine.find_and_replace_dependent_values(sub_step, dependent_on_temp_event)
+
+    assert result["url"] == "https://example.test/token"
+    assert result["headers"]["Cookie"] == "csrf=b"
+
+
+def test_find_and_replace_dependent_values_recurses_into_list_items():
+    engine = DummyBaseEngine()
+    dependent_on_temp_event = [{"status_code": ["200"]}]
+    sub_step = [
+        {"expected": "dependent_on_temp_event[0]['status_code'][0]"},
+    ]
+
+    result = engine.find_and_replace_dependent_values(sub_step, dependent_on_temp_event)
+
+    assert result == [{"expected": "200"}]


### PR DESCRIPTION
## Summary
- replace `eval()` in dependent temp event placeholder replacement with explicit bracket lookup parsing
- preserve the existing `error` fallback when a placeholder cannot be resolved
- fix recursion into nested list items in the same resolver
- add regression coverage for nested dictionary/list placeholders

## Testing
- `py -3.12 -m compileall nettacker\core\lib\base.py tests\core\lib\test_base_engine.py`
- `git diff --check`
- direct function smoke check with dependency stubs because this environment does not have PyYAML/pytest installed