### PR TITLE
docs: fix API usage link

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-WebUI/API Manual usage explained in the [Usage](Usage#api-and-webui) page but let's get into the structure of the request now.
+WebUI/API Manual usage explained in the [Usage](Usage.md#api-and-webui) page but let's get into the structure of the request now.
 
 - [Purpose](#purpose)
 - [Requests Structure](#requests-structure)


### PR DESCRIPTION
## Summary
- update the API docs link to point to `Usage.md#api-and-webui`
- preserve Markdown rendering by using the actual file path plus anchor

## Testing
- `git diff --check`