### PR TITLE
replace removed ssl.wrap_socket() with SSLContext

### DIFF
--- a/nettacker/core/lib/socket.py
+++ b/nettacker/core/lib/socket.py
@@ -26,7 +26,11 @@ def create_tcp_socket(host, port, timeout):
         return None
 
     try:
-        socket_connection = ssl.wrap_socket(socket_connection)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        socket_connection = context.wrap_socket(socket_connection)
         ssl_flag = True
     except Exception:
         socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/nettacker/core/lib/socket.py
+++ b/nettacker/core/lib/socket.py
@@ -30,7 +30,7 @@ def create_tcp_socket(host, port, timeout):
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
         context.minimum_version = ssl.TLSVersion.TLSv1_2
-        socket_connection = context.wrap_socket(socket_connection)
+        socket_connection = context.wrap_socket(socket_connection, server_hostname=host)
         ssl_flag = True
     except Exception:
         socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/nettacker/core/lib/ssl.py
+++ b/nettacker/core/lib/ssl.py
@@ -121,10 +121,13 @@ def create_tcp_socket(host, port, timeout):
         # is_weak_cipher_suite() at the call site. Setting minimum_version here would
         # prevent connecting to servers running TLS 1.0/1.1, producing false negatives
         # in vulnerability detection which would make it the opposite of what this module is for.
+        # minimum_version is set explicitly to MINIMUM_SUPPORTED to make this permissive intent
+        # reliable across platforms, rather than relying on PROTOCOL_TLS_CLIENT's implicit default.
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
-        socket_connection = context.wrap_socket(socket_connection)
+        context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+        socket_connection = context.wrap_socket(socket_connection, server_hostname=host)
         ssl_flag = True
     except Exception:
         socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/nettacker/core/lib/ssl.py
+++ b/nettacker/core/lib/ssl.py
@@ -117,7 +117,14 @@ def create_tcp_socket(host, port, timeout):
         return None
 
     try:
-        socket_connection = ssl.wrap_socket(socket_connection)
+        # Intentionally permissive: this ssl_flag gates is_weak_ssl_version() and
+        # is_weak_cipher_suite() at the call site. Setting minimum_version here would
+        # prevent connecting to servers running TLS 1.0/1.1, producing false negatives
+        # in vulnerability detection which would make it the opposite of what this module is for.
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        socket_connection = context.wrap_socket(socket_connection)
         ssl_flag = True
     except Exception:
         socket_connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/tests/core/lib/test_socket.py
+++ b/tests/core/lib/test_socket.py
@@ -152,7 +152,7 @@ class TestSocketMethod:
         context_instance = mock_ssl_context.return_value
         socket_instance.settimeout.assert_called_with(TIMEOUT)
         socket_instance.connect.assert_called_with((HOST, PORT))
-        context_instance.wrap_socket.assert_called_with(socket_instance)
+        context_instance.wrap_socket.assert_called_with(socket_instance, server_hostname=HOST)
 
     def test_response_conditions_matched_socket_icmp(self, socket_engine, substeps, responses):
         result = socket_engine.response_conditions_matched(

--- a/tests/core/lib/test_socket.py
+++ b/tests/core/lib/test_socket.py
@@ -141,17 +141,18 @@ def responses():
 
 class TestSocketMethod:
     @patch("socket.socket")
-    @patch("ssl.wrap_socket")
-    def test_create_tcp_socket(self, mock_wrap, mock_socket):
+    @patch("ssl.SSLContext")
+    def test_create_tcp_socket(self, mock_ssl_context, mock_socket):
         HOST = "example.com"
         PORT = 80
         TIMEOUT = 60
 
         create_tcp_socket(HOST, PORT, TIMEOUT)
         socket_instance = mock_socket.return_value
+        context_instance = mock_ssl_context.return_value
         socket_instance.settimeout.assert_called_with(TIMEOUT)
         socket_instance.connect.assert_called_with((HOST, PORT))
-        mock_wrap.assert_called_with(socket_instance)
+        context_instance.wrap_socket.assert_called_with(socket_instance)
 
     def test_response_conditions_matched_socket_icmp(self, socket_engine, substeps, responses):
         result = socket_engine.response_conditions_matched(

--- a/tests/core/lib/test_ssl.py
+++ b/tests/core/lib/test_ssl.py
@@ -179,18 +179,19 @@ def connection_params():
 
 class TestSslMethod:
     @patch("socket.socket")
-    @patch("ssl.wrap_socket")
-    def test_create_tcp_socket(self, mock_wrap, mock_socket, connection_params):
+    @patch("ssl.SSLContext")
+    def test_create_tcp_socket(self, mock_ssl_context, mock_socket, connection_params):
         create_tcp_socket(
             connection_params["HOST"], connection_params["PORT"], connection_params["TIMEOUT"]
         )
 
         socket_instance = mock_socket.return_value
+        context_instance = mock_ssl_context.return_value
         socket_instance.settimeout.assert_called_with(connection_params["TIMEOUT"])
         socket_instance.connect.assert_called_with(
             (connection_params["HOST"], connection_params["PORT"])
         )
-        mock_wrap.assert_called_with(socket_instance)
+        context_instance.wrap_socket.assert_called_with(socket_instance)
 
     @patch("nettacker.core.lib.ssl.is_weak_cipher_suite")
     @patch("nettacker.core.lib.ssl.is_weak_ssl_version")

--- a/tests/core/lib/test_ssl.py
+++ b/tests/core/lib/test_ssl.py
@@ -191,7 +191,9 @@ class TestSslMethod:
         socket_instance.connect.assert_called_with(
             (connection_params["HOST"], connection_params["PORT"])
         )
-        context_instance.wrap_socket.assert_called_with(socket_instance)
+        context_instance.wrap_socket.assert_called_with(
+            socket_instance, server_hostname=connection_params["HOST"]
+        )
 
     @patch("nettacker.core.lib.ssl.is_weak_cipher_suite")
     @patch("nettacker.core.lib.ssl.is_weak_ssl_version")


### PR DESCRIPTION
## Proposed change

Python 3.12 removed `ssl.wrap_socket()`, which two places in the codebase were still using directly (`socket.py` and `ssl.py`). Both were wrapped in broad except blocks, so instead of crashing they used to fall back to a plain socket with `ssl_flag=False` meaning SSL detection and the weak-cert/weak-version vuln checks just stopped working on 3.12, with no error at all.

This PR swaps both to use `ssl.SSLContext` instead. The two spots needed different treatment though:

`socket.py`: `ssl_flag` here is just used for scan metadata/logging, so it's safe to lock this down to TLS 1.2+.

`ssl.py`: `ssl_flag` here actually gates whether the weak-version/weak-cipher checks run at all. If I locked this one down too, it would silently stop detecting servers still running TLS 1.0/1.1 which would be the opposite of what the module is supposed to do. So this one stays permissive on purpose, same as the existing `is_weak_cipher_suite()` code already does.

Also updated the two tests that were mocking the now-removed `ssl.wrap_socket` so they mock `ssl.SSLContext` instead.

Fixes #1190
Fixes #1302

## Type of change

- [ ] New core framework functionality
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've **digitally signed** all my commits in this PR
- [x] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [x] I've run `make test` and I confirm all tests passed locally
- [ ] I've added/updated any relevant documentation in the `docs/` folder 
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [ ] I've attached screenshots demonstrating that my code works as intended (if applicable)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision
