### PR TITLE
fix(core): resolve inconsistent port extraction in process_conditions

### DIFF
--- a/nettacker/core/lib/base.py
+++ b/nettacker/core/lib/base.py
@@ -122,6 +122,17 @@ class BaseEngine(ABC):
     ):
         # Remove sensitive keys from headers before submitting to DB
         event = remove_sensitive_header_keys(event)
+        port = (
+            event.get("ports")
+            or event.get("port")
+            or (
+                event.get("url").split(":")[2].split("/")[0]
+                if isinstance(event.get("url"), str)
+                and len(event.get("url").split(":")) >= 3
+                and event.get("url").split(":")[2].split("/")[0].isdigit()
+                else ""
+            )
+        )
         if "save_to_temp_events_only" in event.get("response", ""):
             submit_temp_logs_to_db(
                 {
@@ -130,7 +141,7 @@ class BaseEngine(ABC):
                     "module_name": module_name,
                     "scan_id": scan_id,
                     "event_name": event["response"]["save_to_temp_events_only"],
-                    "port": event.get("ports", ""),
+                    "port": port,
                     "event": event,
                     "data": response,
                 }
@@ -159,15 +170,7 @@ class BaseEngine(ABC):
                     "target": target,
                     "module_name": module_name,
                     "scan_id": scan_id,
-                    "port": event.get("ports")
-                    or event.get("port")
-                    or (
-                        event.get("url").split(":")[2].split("/")[0]
-                        if isinstance(event.get("url"), str)
-                        and len(event.get("url").split(":")) >= 3
-                        and event.get("url").split(":")[2].split("/")[0].isdigit()
-                        else ""
-                    ),
+                    "port": port,
                     "event": " ".join(yaml.dump(event_request_keys).split())
                     + " conditions: "
                     + " ".join(yaml.dump(event["response"]["conditions_results"]).split()),


### PR DESCRIPTION
Fixes #1646. Centralize port extraction in process_conditions() so both normal database logging and temporary database logging share the same port value, resolving empty port values in temp logs.