### PR TITLE
fix: use pathlib stem for cross-platform path parsing in get_languages (#1582)

### DIFF
--- a/nettacker/core/messages.py
+++ b/nettacker/core/messages.py
@@ -33,7 +33,7 @@ def get_languages():
     languages_list = []
 
     for language in Config.path.locale_dir.glob("*.yaml"):
-        languages_list.append(str(language).split("/")[-1].split(".")[0])
+        languages_list.append(language.stem)
     return list(set(languages_list))
 
 


### PR DESCRIPTION
### Summary of Changes
Fixed a Windows compatibility issue in `get_languages()` in `nettacker/core/messages.py`. 

Previously, path string splitting relied on forward slashes (`/`), which fails on Windows operating systems due to backslash (`\`) path separators. Replaced string splitting with `language.stem` using `pathlib.Path` for clean, cross-platform language name extraction.

Fixes #1582