### PR TITLE
Replace eval/exec in dependent value resolution with safe resolver

### DIFF
--- a/nettacker/core/lib/base.py
+++ b/nettacker/core/lib/base.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import re
 import time
 from abc import ABC
 from datetime import datetime
@@ -9,7 +8,11 @@ import yaml
 
 from nettacker.config import Config
 from nettacker.core.messages import messages as _
-from nettacker.core.utils.common import merge_logs_to_list, remove_sensitive_header_keys
+from nettacker.core.utils.common import (
+    merge_logs_to_list,
+    remove_sensitive_header_keys,
+    replace_dependent_expressions,
+)
 from nettacker.database.db import find_temp_events, submit_logs_to_db, submit_temp_logs_to_db
 from nettacker.logger import TerminalCodes, get_logger
 
@@ -57,53 +60,36 @@ class BaseEngine(ABC):
                 time.sleep(0.1)
         return events
 
+    def replace_dependent_value_in_item(self, item, dependent_on_temp_event):
+        """Resolve dependent-value expressions inside one step item.
+
+        Only chains of integer or quoted-string indexes into
+        *dependent_on_temp_event* are supported; anything else is left
+        untouched instead of being evaluated.
+        """
+        if isinstance(item, str):
+            return replace_dependent_expressions(
+                item,
+                "dependent_on_temp_event",
+                dependent_on_temp_event,
+                renderer=str,
+                default="error",
+            )
+        if not isinstance(item, (str, float, int, bytes)):
+            return self.find_and_replace_dependent_values(item, dependent_on_temp_event)
+        return item
+
     def find_and_replace_dependent_values(self, sub_step, dependent_on_temp_event):
         if isinstance(sub_step, dict):
-            for key in copy.deepcopy(sub_step):
-                if not isinstance(sub_step[key], (str, float, int, bytes)):
-                    sub_step[key] = self.find_and_replace_dependent_values(
-                        copy.deepcopy(sub_step[key]), dependent_on_temp_event
-                    )
-                else:
-                    if isinstance(sub_step[key], str):
-                        if "dependent_on_temp_event" in sub_step[key]:
-                            globals().update(locals())
-                            generate_new_step = copy.deepcopy(sub_step[key])
-                            key_name = re.findall(
-                                re.compile(
-                                    "dependent_on_temp_event\\[\\S+\\]\\['\\S+\\]\\[\\S+\\]"
-                                ),
-                                generate_new_step,
-                            )[0]
-                            try:
-                                key_value = eval(key_name)
-                            except Exception:
-                                key_value = "error"
-                            sub_step[key] = sub_step[key].replace(key_name, key_value)
+            for key in sub_step:
+                sub_step[key] = self.replace_dependent_value_in_item(
+                    sub_step[key], dependent_on_temp_event
+                )
         if isinstance(sub_step, list):
-            value_index = 0
-            for key in copy.deepcopy(sub_step):
-                if type(sub_step[value_index]) not in [str, float, int, bytes]:
-                    sub_step[key] = self.find_and_replace_dependent_values(
-                        copy.deepcopy(sub_step[value_index]), dependent_on_temp_event
-                    )
-                else:
-                    if isinstance(sub_step[value_index], str):
-                        if "dependent_on_temp_event" in sub_step[value_index]:
-                            globals().update(locals())
-                            generate_new_step = copy.deepcopy(sub_step[key])
-                            key_name = re.findall(
-                                re.compile("dependent_on_temp_event\\['\\S+\\]\\[\\S+\\]"),
-                                generate_new_step,
-                            )[0]
-                            try:
-                                key_value = eval(key_name)
-                            except Exception:
-                                key_value = "error"
-                            sub_step[value_index] = sub_step[value_index].replace(
-                                key_name, key_value
-                            )
-                value_index += 1
+            for index, item in enumerate(sub_step):
+                sub_step[index] = self.replace_dependent_value_in_item(
+                    item, dependent_on_temp_event
+                )
         return sub_step
 
     def process_conditions(

--- a/nettacker/core/lib/http.py
+++ b/nettacker/core/lib/http.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import copy
+import operator
 import random
 import re
 import time
@@ -18,6 +19,15 @@ from nettacker.core.utils.common import (
 )
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+RESPONSETIME_COMPARISONS = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    "<=": operator.le,
+    ">": operator.gt,
+    "<": operator.lt,
+}
 
 
 async def perform_request_action(action, request_options):
@@ -73,23 +83,17 @@ def response_conditions_matched(sub_step, response):
                 except TypeError:
                     condition_results["headers"][header] = []
         if condition == "responsetime":
-            if len(conditions[condition].split()) == 2 and conditions[condition].split()[0] in [
-                "==",
-                "!=",
-                ">=",
-                "<=",
-                ">",
-                "<",
-            ]:
-                exec(
-                    "condition_results['responsetime'] = response['responsetime'] if ("
-                    + "response['responsetime'] {0} float(conditions['responsetime'].split()[-1])".format(
-                        conditions["responsetime"].split()[0]
-                    )
-                    + ") else []"
-                )
-            else:
-                condition_results["responsetime"] = []
+            condition_results["responsetime"] = []
+            parts = conditions[condition].split()
+            if len(parts) == 2 and parts[0] in RESPONSETIME_COMPARISONS:
+                try:
+                    threshold = float(parts[-1])
+                except ValueError:
+                    pass
+                else:
+                    comparison = RESPONSETIME_COMPARISONS[parts[0]]
+                    if comparison(response["responsetime"], threshold):
+                        condition_results["responsetime"] = response["responsetime"]
     if condition_type.lower() == "or":
         # if one of the values are matched, it will be a string or float object in the array
         # we count False in the array and if it's not all []; then we know one of the conditions

--- a/nettacker/core/utils/common.py
+++ b/nettacker/core/utils/common.py
@@ -1,3 +1,4 @@
+import ast
 import copy
 import ctypes
 import datetime
@@ -18,17 +19,95 @@ from nettacker import logger
 log = logger.get_logger()
 
 
+class UnsafeDependentExpression(ValueError):
+    """A dependent-value expression is outside the supported grammar."""
+
+
+# Matches `<root>[<integer>|<'key'>|"key"]...` chains only. Anything else
+# (calls, attributes, operators, bare names) is not matched at all.
+DEPENDENT_INDEX_PATTERN = r"(?:\[-?\d+\]|\['[^']*'\]|\[\"[^\"]*\"\])+"
+
+
+def find_dependent_expressions(text, root_name):
+    """Find all supported `<root_name>[...]...` expressions inside a string."""
+    return re.findall(re.escape(root_name) + DEPENDENT_INDEX_PATTERN, text)
+
+
+def parse_dependent_expression(expression, root_name):
+    """Validate a dependent-value expression and return its index path.
+
+    Only chains of integer or quoted-string subscript literals into one root
+    name are accepted (e.g. ``root[0]['headers']['Set-Cookie'][1]``). Anything
+    else raises UnsafeDependentExpression instead of being evaluated.
+    """
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise UnsafeDependentExpression(expression) from exc
+    node = tree.body
+    path = []
+    while isinstance(node, ast.Subscript):
+        index = node.slice
+        if isinstance(index, ast.UnaryOp) and isinstance(index.op, ast.USub):
+            if (
+                isinstance(index.operand, ast.Constant)
+                and isinstance(index.operand.value, int)
+                and not isinstance(index.operand.value, bool)
+            ):
+                path.append(-index.operand.value)
+                node = node.value
+                continue
+            raise UnsafeDependentExpression(expression)
+        if (
+            isinstance(index, ast.Constant)
+            and isinstance(index.value, (int, str))
+            and not isinstance(index.value, bool)
+        ):
+            path.append(index.value)
+            node = node.value
+            continue
+        raise UnsafeDependentExpression(expression)
+    if not isinstance(node, ast.Name) or node.id != root_name or not path:
+        raise UnsafeDependentExpression(expression)
+    path.reverse()
+    return path
+
+
+def resolve_dependent_value(expression, root_name, root_value):
+    """Resolve a supported dependent-value expression against its root object."""
+    value = root_value
+    for index in parse_dependent_expression(expression, root_name):
+        value = value[index]
+    return value
+
+
+def replace_dependent_expressions(text, root_name, root_value, renderer, default):
+    """Replace every supported dependent expression in *text* with its value.
+
+    Expressions outside the grammar are never evaluated; failures to resolve
+    (missing key/index, wrong types) render *default*, matching the previous
+    ``eval`` error fallback behaviour.
+    """
+    result = text
+    for expression in sorted(set(find_dependent_expressions(text, root_name))):
+        try:
+            rendered = renderer(resolve_dependent_value(expression, root_name, root_value))
+        except Exception:
+            rendered = default
+        result = result.replace(expression, rendered)
+    return result
+
+
 def replace_dependent_response(log, response_dependent):
-    """The `response_dependent` is needed for `eval` below."""
+    """Replace ``response_dependent[...]`` expressions inside a log line."""
     if str(log):
-        key_name = re.findall(re.compile("response_dependent\\['\\S+\\]"), log)
-        for i in key_name:
-            try:
-                key_value = eval(i)
-            except Exception:
-                key_value = "response dependent error"
-            log = log.replace(i, " ".join(key_value))
-        return log
+        return replace_dependent_expressions(
+            log,
+            "response_dependent",
+            response_dependent,
+            lambda value: " ".join(value),
+            "response dependent error",
+        )
 
 
 def merge_logs_to_list(result, log_list=None):

--- a/tests/core/lib/test_base.py
+++ b/tests/core/lib/test_base.py
@@ -1,0 +1,97 @@
+import importlib
+
+import pytest
+
+base = importlib.import_module("nettacker.core.lib.base")
+
+# ----------------------------
+# Helpers
+# ----------------------------
+
+
+class DummyEngine(base.BaseEngine):
+    pass
+
+
+@pytest.fixture
+def engine():
+    return DummyEngine()
+
+
+TEMP_EVENT = [
+    {
+        "status_code": ["200"],
+        "content": ["<html>csrf_token=abc</html>"],
+        "headers": {"Set-Cookie": ["csrftoken=abc123", "sessionid=xyz789"]},
+    }
+]
+
+# ----------------------------
+# find_and_replace_dependent_values
+# ----------------------------
+
+
+def test_dict_branch_resolves_shipped_subdomain_shapes(engine):
+    """Shapes taken from nettacker/modules/scan/subdomain.yaml."""
+    sub_step = {
+        "headers": {"Cookie": "dependent_on_temp_event[0]['headers']['Set-Cookie'][1]"},
+        "data": {"csrfmiddlewaretoken": "dependent_on_temp_event[0]['content'][0]"},
+    }
+    result = engine.find_and_replace_dependent_values(sub_step, TEMP_EVENT)
+    assert result["headers"]["Cookie"] == "sessionid=xyz789"
+    assert result["data"]["csrfmiddlewaretoken"] == "<html>csrf_token=abc</html>"
+
+
+def test_list_branch_and_nested_structures(engine):
+    sub_step = [
+        {"regex": "status dependent_on_temp_event[0]['status_code'][0]"},
+        ["nested dependent_on_temp_event[0]['status_code'][0]"],
+        5,
+        b"bytes-untouched",
+    ]
+    result = engine.find_and_replace_dependent_values(sub_step, TEMP_EVENT)
+    assert result[0]["regex"] == "status 200"
+    assert result[1][0] == "nested 200"
+    assert result[2] == 5
+    assert result[3] == b"bytes-untouched"
+
+
+def test_plain_text_expression_mid_string(engine):
+    """Shape from nettacker/modules/scan/waf.yaml: expression inside prose/regex fields."""
+    sub_step = {
+        "log": "WAF detected, Got differenet response dependent_on_temp_event[0]['status_code'][0]",
+        "response": {
+            "conditions": {
+                "status_code": {"regex": "dependent_on_temp_event[0]['status_code'][0]"}
+            }
+        },
+    }
+    result = engine.find_and_replace_dependent_values(sub_step, TEMP_EVENT)
+    assert result["log"] == "WAF detected, Got differenet response 200"
+    assert result["response"]["conditions"]["status_code"]["regex"] == "200"
+
+
+def test_unresolvable_dependency_falls_back_to_error(engine):
+    sub_step = {"url": "dependent_on_temp_event[0]['missing'][0]"}
+    result = engine.find_and_replace_dependent_values(sub_step, TEMP_EVENT)
+    assert result["url"] == "error"
+
+
+def test_hostile_expressions_are_not_evaluated(engine):
+    """Issue #1651 payload must not execute and must not corrupt the step."""
+    payload = "dependent_on_temp_event[0]['a'][__import__('platform').system()!='']"
+    sub_step = {"data": f"prefix {payload} suffix"}
+    result = engine.find_and_replace_dependent_values(sub_step, TEMP_EVENT)
+    # only the whitelisted prefix [0]['a'] resolves (to the error fallback);
+    # the executable tail stays literal text.
+    assert result["data"] == "prefix error[__import__('platform').system()!=''] suffix"
+
+
+def test_no_globals_pollution(engine):
+    """globals().update(locals()) used to leak frame locals into module globals."""
+    engine.find_and_replace_dependent_values(
+        {"k": "dependent_on_temp_event[0]['status_code'][0]"}, TEMP_EVENT
+    )
+    module_globals = vars(base)
+    for leaked in ("key_name", "key_value", "generate_new_step", "sub_step", "temp_event"):
+        assert leaked not in module_globals, f"{leaked} leaked into module globals"

--- a/tests/core/lib/test_user_added_http_headers.py
+++ b/tests/core/lib/test_user_added_http_headers.py
@@ -323,6 +323,83 @@ def test_response_conditions_responsetime(monkeypatch):
     assert http.response_conditions_matched(sub_step, response) == {}
 
 
+@pytest.mark.parametrize(
+    "condition, responsetime, matched",
+    [
+        ("== 0.5", 0.5, True),
+        ("== 0.5", 0.4999, False),
+        ("!= 0.5", 0.7, True),
+        ("!= 0.5", 0.5, False),
+        (">= 0.5", 0.5, True),
+        (">= 0.5", 0.4999, False),
+        ("<= 0.5", 0.5, True),
+        ("<= 0.5", 0.5001, False),
+        ("> 0.5", 0.5001, True),
+        ("> 0.5", 0.5, False),
+        ("< 0.5", 0.4999, True),
+        ("< 0.5", 0.5, False),
+    ],
+)
+def test_response_conditions_responsetime_all_operators(condition, responsetime, matched):
+    sub_step = {
+        "response": {
+            "condition_type": "and",
+            "conditions": {"responsetime": condition},
+        },
+    }
+    response = {
+        "status_code": "200",
+        "url": "http://owasp.org:443",
+        "reason": "OK",
+        "headers": {},
+        "responsetime": responsetime,
+        "content": "body",
+    }
+    result = http.response_conditions_matched(sub_step, response)
+    if matched:
+        assert result["responsetime"] == responsetime
+    else:
+        # a failed condition empties the whole result set
+        assert result == {}
+
+
+def test_response_conditions_responsetime_rejects_bad_operator():
+    sub_step = {
+        "response": {
+            "condition_type": "and",
+            "conditions": {"responsetime": "~ 0.5"},
+        },
+    }
+    response = {
+        "status_code": "200",
+        "url": "",
+        "reason": "",
+        "headers": {},
+        "responsetime": 0.1,
+        "content": "",
+    }
+    assert http.response_conditions_matched(sub_step, response) == {}
+
+
+def test_response_conditions_responsetime_rejects_non_numeric_threshold():
+    """A non-numeric threshold yields [] instead of raising like the old exec()."""
+    sub_step = {
+        "response": {
+            "condition_type": "and",
+            "conditions": {"responsetime": ">= fast"},
+        },
+    }
+    response = {
+        "status_code": "200",
+        "url": "",
+        "reason": "",
+        "headers": {},
+        "responsetime": 0.1,
+        "content": "",
+    }
+    assert http.response_conditions_matched(sub_step, response) == {}
+
+
 # ----------------------------
 # Tests for HttpEngine.run
 # ----------------------------

--- a/tests/core/utils/test_common.py
+++ b/tests/core/utils/test_common.py
@@ -5,6 +5,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nettacker.core.utils import common as common_utils
+from nettacker.core.utils.common import (
+    UnsafeDependentExpression,
+    find_dependent_expressions,
+    parse_dependent_expression,
+    replace_dependent_response,
+    resolve_dependent_value,
+)
 
 
 def test_arrays_to_matrix():
@@ -292,3 +299,132 @@ def test_fuzzer_repeater_perform_unknown_interceptor_alongside_allowed_raises():
 
 def test_allowed_interceptors_registry_is_restricted():
     assert set(common_utils.ALLOWED_INTERCEPTORS) == {"generate_and_replace_md5"}
+
+
+# ----------------------------
+# Safe dependent-value resolution (replaces eval/exec, see issue #1651)
+# ----------------------------
+
+TEMP_EVENT = [
+    {
+        "status_code": ["200"],
+        "content": ["<html>ns1.example.com</html>"],
+        "headers": {"Set-Cookie": ["csrftoken=abc123", "sessionid=xyz789"]},
+    }
+]
+
+
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        ("dependent_on_temp_event[0]['status_code'][0]", "200"),
+        ("dependent_on_temp_event[0]['content'][0]", "<html>ns1.example.com</html>"),
+        ("dependent_on_temp_event[0]['headers']['Set-Cookie'][1]", "sessionid=xyz789"),
+    ],
+)
+def test_resolve_dependent_value_shipped_module_shapes(expression, expected):
+    """Every dependent_on_temp_event expression used by shipped modules resolves."""
+    assert resolve_dependent_value(expression, "dependent_on_temp_event", TEMP_EVENT) == expected
+
+
+def test_parse_dependent_expression_returns_index_path():
+    assert parse_dependent_expression(
+        "dependent_on_temp_event[0]['headers']['Set-Cookie'][1]",
+        "dependent_on_temp_event",
+    ) == [0, "headers", "Set-Cookie", 1]
+    assert parse_dependent_expression("response_dependent['service']", "response_dependent") == [
+        "service"
+    ]
+    assert parse_dependent_expression('root[-1]["k"]', "root") == [-1, "k"]
+
+
+def test_find_dependent_expressions_multiple_in_one_string():
+    log = "response_dependent['status_code'] response_dependent['headers']['Location']"
+    assert find_dependent_expressions(log, "response_dependent") == [
+        "response_dependent['status_code']",
+        "response_dependent['headers']['Location']",
+    ]
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        # payload from issue #1651: import must never run
+        "dependent_on_temp_event[0]['a'][__import__('platform').system()!='']",
+        "dependent_on_temp_event[__import__('os').system('true')]",
+        # attribute access after the chain
+        "dependent_on_temp_event[0].keys",
+        # non-literal subscripts
+        "dependent_on_temp_event[name]",
+        "dependent_on_temp_event[0 + 1]",
+        "dependent_on_temp_event[True]",
+        # call instead of subscript chain
+        "__import__('os').getcwd()",
+        # bare root without any index
+        "dependent_on_temp_event",
+        # wrong root name
+        "response_dependent['service']",
+    ],
+)
+def test_parse_dependent_expression_rejects_non_whitelisted_forms(expression):
+    with pytest.raises(UnsafeDependentExpression):
+        parse_dependent_expression(expression, "dependent_on_temp_event")
+
+
+def test_replace_dependent_response_shipped_module_shapes():
+    response = {
+        "status_code": ["200"],
+        "url": ["http://target/"],
+        "service": ["http"],
+        "content": ["Apache Tomcat"],
+        "headers": {"Server": ["Apache"], "Last-Modified": ["Tue, 12 Mar 2024"]},
+    }
+    assert (
+        replace_dependent_response("found: response_dependent['status_code']", response)
+        == "found: 200"
+    )
+    assert (
+        replace_dependent_response("u=response_dependent['url']", response) == "u=http://target/"
+    )
+    assert (
+        replace_dependent_response(
+            "srv: response_dependent['headers']['Server'] mod: "
+            "response_dependent['headers']['Last-Modified']",
+            response,
+        )
+        == "srv: Apache mod: Tue, 12 Mar 2024"
+    )
+
+
+def test_replace_dependent_response_multiple_expressions():
+    response = {
+        "status_code": ["301"],
+        "headers": {"Location": ["http://target/login"]},
+    }
+    log = "moved response_dependent['status_code'] to response_dependent['headers']['Location']"
+    assert replace_dependent_response(log, response) == "moved 301 to http://target/login"
+
+
+def test_replace_dependent_response_unresolvable_uses_default():
+    response = {"status_code": ["200"]}
+    assert (
+        replace_dependent_response("x response_dependent['missing_key']", response)
+        == "x response dependent error"
+    )
+    assert replace_dependent_response("", {}) is None
+
+
+def test_replace_dependent_response_never_evaluates_hostile_text():
+    """Expressions outside the grammar stay literal; nothing gets executed."""
+    response = {}
+    hostile = "response_dependent['a' if __import__('platform').system() else 'b']"
+    assert replace_dependent_response(hostile, response) == hostile
+
+
+def test_replace_dependent_expression_string_subscript_is_data_only():
+    """Quoted keys are plain dict lookups, never attribute/call resolution."""
+    response = {"__class__": ["not-a-class"]}
+    assert (
+        replace_dependent_response("v=response_dependent['__class__']", response)
+        == "v=not-a-class"
+    )

--- a/tests/test_yaml_schema_and_regex.py
+++ b/tests/test_yaml_schema_and_regex.py
@@ -294,3 +294,44 @@ def test_yaml_schema_and_regex_valid(yaml_file):
 
     for regex in regexes:
         assert is_valid_regex(regex), f"Invalid regex in {yaml_file}: `{regex}`"
+
+
+# ----------------------------
+# Dependent-value expressions must stay inside the safe resolver grammar
+# ----------------------------
+
+DEPENDENT_EXPRESSION_PATTERN = re.compile(
+    r"dependent_on_temp_event(?:\[-?\d+\]|\['[^']*'\]|\[\"[^\"]*\"\])+"
+)
+RESPONSE_DEPENDENT_EXPRESSION_PATTERN = re.compile(
+    r"response_dependent(?:\[-?\d+\]|\['[^']*'\]|\[\"[^\"]*\"\])+"
+)
+
+
+@pytest.mark.parametrize("yaml_file", list(get_yaml_files()))
+def test_dependent_value_expressions_use_safe_grammar(yaml_file):
+    """Every dependent-value expression in module YAMLs must be resolvable
+    without eval/exec (issue #1651)."""
+    from nettacker.core.utils.common import parse_dependent_expression
+
+    content = open(yaml_file).read()
+
+    for match in DEPENDENT_EXPRESSION_PATTERN.findall(content):
+        parse_dependent_expression(match, "dependent_on_temp_event")
+
+    for match in RESPONSE_DEPENDENT_EXPRESSION_PATTERN.findall(content):
+        parse_dependent_expression(match, "response_dependent")
+
+    for line_number, line in enumerate(content.splitlines(), start=1):
+        for root_name, pattern in (
+            ("dependent_on_temp_event", DEPENDENT_EXPRESSION_PATTERN),
+            ("response_dependent", RESPONSE_DEPENDENT_EXPRESSION_PATTERN),
+        ):
+            # the bare root name also appears as a YAML key declaring the
+            # dependency (e.g. `dependent_on_temp_event: event_name`);
+            # only `root[...` occurrences must be safe expressions.
+            stripped = re.sub(pattern, "", line)
+            assert f"{root_name}[" not in stripped, (
+                f"{yaml_file}:{line_number}: dependent-value syntax outside the "
+                f"safe resolver grammar: {line.strip()}"
+            )


### PR DESCRIPTION
Module YAML content reached `eval()` during dependent-value resolution (`find_and_replace_dependent_values` in `core/lib/base.py`, `replace_dependent_response` in `core/utils/common.py`) and `exec()` built via `.format()` for `responsetime` conditions. Since `\S+` captures arbitrary Python source, any module YAML could execute code (the PoC in #1651 runs `__import__` before failing). Module files are shared data, so data-that-executes-code is worth closing.

## What changed

- New fail-closed resolver in `nettacker/core/utils/common.py`: a strict finder regex accepts only `<root>[<int>|'<key'>|"key"]...` chains, an AST walk re-validates every slice as an `int`/`str` constant (bools rejected), and resolution is a plain index-path walk. Anything else is never evaluated.
- Both `eval` sites in `base.py` rewritten on top of it; the two `globals().update(locals())` calls are gone.
- `replace_dependent_response` uses the same resolver with the original `" ".join(...)` rendering and error fallback.
- The `responsetime` branch uses an `operator` map instead of `exec`.

## Compatibility

All 15 unique `dependent_on_temp_event`/`response_dependent` expressions shipped under `nettacker/modules` resolve to identical values before and after (verified expression-by-expression), including mid-string contexts in `subdomain.yaml`, `waf.yaml`, `log4j_cve_2021_44228.yaml` and `geoserver_cve_2024_36401.yaml`. A per-module test now asserts every dependent-value expression in shipped YAML stays inside the safe grammar.

Fixes #1651

## Tests

- New `tests/core/lib/test_base.py`: shipped shapes, error fallback, hostile-payload inertness, frame-local leak regression.
- Resolver unit tests + rejected-form parametrization (issue payload, attribute access, name/binop/call subscripts, wrong root).
- All six responsetime operators truth-table tested; bad operator and non-numeric threshold covered.
- `pytest tests/`: 511 passed; the 3 failures reproduce identically on a clean checkout under macOS and are unrelated.

Commits are DCO-signed.
