### PR TITLE
Update installation.md - add pyenv info

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -2,154 +2,186 @@
 
 You have multiple options for installing OWASP Nettacker, each with specific instructions provided in dedicated sections below. 
 
-
-### Supported Platforms
-
-OWASP Nettacker is designed to run on Linux and macOS systems. However, you can leverage the Docker image to run it on other operating systems as well. Although native Windows support was initially dropped, we are currently working towards reintroducing it in future versions, along with FreeBSD support.
-
-PLEASE NOTE: Starting from Nettacker version 0.3.1 the support for Python2 and Python <3.10 has been dropped. If you have a requirement to use Nettacker on Python 2.x or 3.0-3.9 you can use the legacy version of Nettacker [v0.0.2](https://github.com/OWASP/Nettacker/releases/tag/0.0.2) 
+PLEASE NOTE: OWASP Nettacker currently supports Python 3.11 - 3.12. Work to make Nettacker compatible with
+later Python versions is ongoing. Because newer operating systems may provide an
+unsupported Python version by default, the examples below use
+[pyenv](https://github.com/pyenv/pyenv) to install and select Python 3.11.15 explicitly.
 
 
-PLEASE NOTE: Python version 3.10-3.12 is required to run Nettacker.  You can check the version of Python3 installed by running:
+Nettacker can run natively on Linux, macOS and FreeBSD. Users of other operating systems
+can run Nettacker with Docker. Although native Windows support was initially dropped, we
+are currently working towards reintroducing it in future versions.
 
-```
-python3 -V
-```
+> [!NOTE]
+> Starting with Nettacker 0.3.1, Python 2 and Python versions earlier than 3.10 are no
+> longer supported. For those Python versions, use the legacy
+> [Nettacker 0.0.2 release](https://github.com/OWASP/Nettacker/releases/tag/0.0.2).
 
+## Prerequisites
 
+Nettacker depends on system libraries and build tools. On Debian or Ubuntu you can install them
+with:
 
-### Pre-requisites
-
-OWASP Nettacker depends on several libraries and tools which you might need to install if they are not already installed on your system:
-
-* python3-dev
-* python3-pip
-* libcurl4-openssl-dev
-* libcurl4-gnutls-dev
-* librtmp-dev
-* libssl-dev
-* libpq-dev (required if you wish to use PostgreSQL database)
-* libffi-dev 
-* musl-dev 
-* make
-* gcc 
-* git
-
-Before using this software, please install the prerequisites by following the commands below):
-
-
-Install Python3, PIP and VENV first (e.g. on Debian Linux/Ubuntu):
-```
+```bash
 sudo apt-get update
-sudo apt-get install -y python3 python3-dev python3-pip python3-venv
-pip3 install --upgrade pip3
+sudo apt-get install -y \
+    build-essential curl git libbz2-dev libcurl4-openssl-dev libffi-dev liblzma-dev \
+    libncursesw5-dev libpq-dev libreadline-dev librtmp-dev libsqlite3-dev libssl-dev \
+    libxml2-dev libxmlsec1-dev tk-dev xz-utils zlib1g-dev
 ```
 
+`libpq-dev` is only required when using PostgreSQL. Other Linux distributions and macOS
+provide equivalent packages through their package managers.
 
-### Install Nettacker From PyPI Using PIPX
+## Install Python 3.11.15 with pyenv
 
-Installing OWASP Nettacker using `pipx` is a convenient method for managing Python applications with isolated environments. `pipx` ensures that each installed tool has its own environment, avoiding dependency conflicts.
+Install pyenv by following its
+[installation instructions](https://github.com/pyenv/pyenv#installation), including the
+shell setup for your platform. Then open a new terminal and run:
 
-Here’s how you can install OWASP Nettacker using `pipx`:
-
-1. Install pipx using apt or pip
-
-   
-Using apt:
-```
-sudo apt update
-sudo apt install pipx
-pipx ensurepath
-pipx --version
-```
-or install pipx using using pip:
-
-```
-python3 -m pip install --user pipx
-python3 -m pipx ensurepath
+```bash
+pyenv install 3.11.15
+"$(pyenv prefix 3.11.15)/bin/python" --version
 ```
 
-2. Install **nettacker** using pipx
-```
-pipx install nettacker
-nettacker --help
-```
-### Install Nettacker from PyPI using PIP
+The final command should print `Python 3.11.15`. When working in a dedicated directory or
+a cloned Nettacker repository, use the following command to select it automatically
+whenever you enter that directory and pyenv's shell integration is active:
 
-
-Starting from version 0.4.0 Nettacker and can be installed directly from PyPI.
-
-```
-sudo apt update
-sudo apt install python3-venv python3-pip
-python3 -m venv venv
-. venv/bin/activate
-pip3 install nettacker
-nettacker --help
+```bash
+pyenv local 3.11.15
 ```
 
-### Install Nettacker using Git Clone and PIP
+Choose one of the installation methods below.
 
+## Install from source with Poetry
+
+Install [Poetry](https://python-poetry.org/docs/#installation) if it is not already
+available. One option is to install Poetry with pipx:
+
+```bash
+pipx install poetry
 ```
-sudo apt update
-sudo apt install python3-venv python3-pip git
-python3 -m venv venv
-. venv/bin/activate
-git clone https://github.com/OWASP/Nettacker --depth 1
+
+Clone Nettacker, select Python 3.11.15, and tell Poetry to create its environment with that
+interpreter:
+
+```bash
+git clone https://github.com/OWASP/Nettacker.git --depth 1
 cd Nettacker
-pip3 install .
-python3 nettacker.py --help
-```
-
-You can also run Nettacker after installation like this:
-
-```
-nettacker --help
-```
-
-### Install Nettacker using Git Clone and Poetry
-
-```
-sudo apt update
-sudo apt install python3-poetry git
-git clone https://github.com/OWASP/Nettacker --depth 1
-cd Nettacker
+pyenv local 3.11.15
+poetry env use "$(pyenv prefix 3.11.15)/bin/python"
 poetry install
 poetry run nettacker --help
 ```
 
-### What Happened to requirements.txt in Nettacker?
+Run Nettacker through Poetry while working in the repository:
 
-In recent updates to OWASP Nettacker, the project has transitioned away from using the traditional `requirements.txt` file for dependency management. Starting from version 0.4.0, Nettacker adopted Poetry as its package manager instead of the `requirements.txt` file. Poetry simplifies dependency management, handling both the installation of dependencies and packaging more efficiently.
-
-Now, the dependencies for Nettacker are listed in `pyproject.toml`, which is a modern PEP 518 standard.  `pyproject.toml` is also used by Poetry package manager, and the installation process follows a different approach:
-
- You can install Nettacker directly from PyPI with the command:
- `pip3 install nettacker` 
- or if you have already cloned Nettacker git repo you can run:
- 
- `pip install .` 
- 
-inside the Nettacker folder.
-
-
-To see the list of command options you can use:
-
-```
-nettacker --help 
+```bash
+poetry run nettacker --show-all-modules
+poetry run nettacker --help
 ```
 
-or 
+Only scan systems that you own or are authorized to test.
 
-```
-nettacker -h
+## Install from PyPI with pip and venv
+
+Create a project directory, select Python 3.11.15, and create an isolated virtual
+environment. If `.venv` already exists, rename or remove it first because creating a venv
+does not replace an existing environment's Python interpreter:
+
+```bash
+mkdir nettacker-env
+cd nettacker-env
+pyenv local 3.11.15
+"$(pyenv prefix 3.11.15)/bin/python" -m venv .venv
+. .venv/bin/activate
+python --version
+python -m pip install --upgrade pip
+python -m pip install nettacker
+nettacker --help
 ```
 
-### Install Nettacker Using Docker
+The version check must print `Python 3.11.15`. The explicit interpreter path ensures that
+the virtual environment uses Python 3.11.15 even if pyenv's shims are not active.
 
-```
-docker pull owasp/nettacker
-docker run -it owasp/nettacker /bin/bash
+Activate the environment before using Nettacker in a new terminal:
+
+```bash
+cd nettacker-env
+. .venv/bin/activate
+nettacker --show-all-modules
 ```
 
-For usage instructions and examples please read [Usage.md](Usage.md)
+Leave the virtual environment with `deactivate`.
+
+To install the current source tree with pip instead of installing the PyPI release:
+
+```bash
+git clone https://github.com/OWASP/Nettacker.git --depth 1
+cd Nettacker
+pyenv local 3.11.15
+"$(pyenv prefix 3.11.15)/bin/python" -m venv .venv
+. .venv/bin/activate
+python --version
+python -m pip install --upgrade pip
+python -m pip install .
+nettacker --help
+```
+
+## Install from PyPI with pipx
+
+pipx installs command-line applications into isolated environments. Install
+[pipx](https://pipx.pypa.io/stable/installation/) with your operating system's package
+manager, then install Nettacker using the Python 3.11.15 interpreter managed by pyenv:
+
+```bash
+pipx ensurepath
+pipx install --python "$(pyenv prefix 3.11.15)/bin/python" nettacker
+nettacker --help
+```
+
+Open a new terminal after `pipx ensurepath` if `nettacker` is not immediately available.
+Verify the interpreter used by the pipx environment with:
+
+```bash
+pipx runpip nettacker debug --verbose
+```
+
+The output should report Python 3.11.15. Upgrade or remove the installation with:
+
+```bash
+pipx upgrade nettacker
+pipx uninstall nettacker
+```
+
+## Why there is no requirements.txt
+
+Starting with version 0.4.0, Nettacker moved from a traditional `requirements.txt` file to
+Poetry for dependency management and packaging. The project dependencies and package
+metadata are now declared in `pyproject.toml`, the modern Python packaging standard used
+by Poetry and pip.
+
+After installation, display the available command-line options with:
+
+```bash
+nettacker --help
+```
+
+## Install with Docker
+
+```bash
+docker run --rm owasp/nettacker --help
+```
+
+This runs the latest released version. To try the current development version, run:
+
+```bash
+docker run --rm owasp/nettacker:dev --help
+```
+
+The `dev` image is built from the latest changes on the `master` branch after the Docker
+tests pass. It may contain features and fixes that have not been released yet and can be
+less stable than the standard image (with the `latest` tag).
+
+For command examples, see the [usage guide](Usage.md).


### PR DESCRIPTION
## Proposed change

Updated installation instructions for OWASP Nettacker, adding information on how to use `pyenv` to run Nettacker on systems with Python versions > 3.12

<!--
- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [x] Documentation/localization improvement
- [ ] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

#