### PR TITLE
Bump Python base image version to 3.11.16-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### Multi-stage Dockerfile
 # Define the base image only once as a build argument
-ARG PYTHON_IMAGE=python:3.11.15-slim
+ARG PYTHON_IMAGE=python:3.11.16-slim
       
 ### Build stage
 FROM ${PYTHON_IMAGE} AS builder


### PR DESCRIPTION
Updating to Python 3.11.16 (which is a security updates release)

## Type of change

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [ ] Test coverage improvement
- [x] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)
