### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/nettacker/core/lib/http.py
+++ b/nettacker/core/lib/http.py
@@ -7,7 +7,10 @@ import re
 import time
 
 import aiohttp
-import uvloop
+try:
+    import uvloop
+except ImportError:
+    uvloop = None
 
 from nettacker.core.lib.base import BaseEngine
 from nettacker.core.utils.common import (
@@ -17,7 +20,8 @@ from nettacker.core.utils.common import (
     reverse_and_regex_condition,
 )
 
-asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+if uvloop is not None:
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 
 async def perform_request_action(action, request_options):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ pyyaml = "^6.0.1"
 requests = "^2.32.3"
 sqlalchemy = "^2.0.22"
 texttable = "^1.7.0"
-uvloop = "^0.21.0"
+uvloop = { version = "^0.21.0", markers = "sys_platform != 'win32'" }
 zipp = "^3.19.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION

### Summary

Nettacker depends on **uvloop** unconditionally:

- `pyproject.toml`: `uvloop = "^0.21.0"` (no platform marker)
- `nettacker/core/lib/http.py`: `import uvloop` +
  `asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())`

uvloop is Unix-only — on Windows, `pip install -e .` fails with
`RuntimeError: uvloop does not support Windows at the moment`, so the whole
package cannot be installed on Windows.

Fix (same pattern as other cross-platform tools):

- `pyproject.toml`: add a platform marker so pip skips uvloop on Windows:
  ```toml
  uvloop = { version = "^0.21.0", markers = "sys_platform != 'win32'" }
  ```
- `http.py`: guard the import and the event-loop policy setup:
  ```python
  try:
      import uvloop
  except ImportError:
      uvloop = None
  ...
  if uvloop is not None:
      asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
  ```

On Windows the asyncio default event loop is used; on Unix behavior is
unchanged.

### Verification (Windows, Python 3.13.9)

- `python -m py_compile nettacker/core/lib/http.py` → OK
- `pip install -e . --ignore-requires-python` (uvloop marker active) → uvloop
  no longer attempted; install proceeds past the previous `RuntimeError`

Note: `python = "^3.10, <3.13"` also excludes Python 3.13; relaxing that upper
bound is a separate follow-up after 3.13 compatibility is verified upstream.

### Files changed

- `pyproject.toml` (uvloop marker)
- `nettacker/core/lib/http.py` (guarded import + policy)