### PR TITLE
fix(api): improve exception handling and validation in api engine

### DIFF
--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -462,7 +462,13 @@ def get_results():
     page = get_value(flask_request, "page")
     if not page:
         page = 1
-    return jsonify(select_reports(int(page))), 200
+    try:
+        page_num = int(page)
+        if page_num < 1:
+            page_num = 1
+    except (ValueError, TypeError):
+        return jsonify(structure(status="error", msg="Invalid page number")), 400
+    return jsonify(select_reports(page_num)), 200
 
 
 @app.route("/results/get", methods=["GET"])
@@ -479,8 +485,12 @@ def get_result_content():
         return jsonify(structure(status="error", msg=_("invalid_scan_id"))), 400
 
     try:
-        filename, file_content = get_scan_result(scan_id)
-    except Exception:
+        res = get_scan_result(scan_id)
+        if not res or not isinstance(res, tuple):
+            return jsonify(structure(status="error", msg=_("no_scan_data_found"))), 404
+        filename, file_content = res
+    except Exception as e:
+        logger.error(f"Error fetching scan result for scan_id {scan_id}: {e}")
         return jsonify(structure(status="error", msg="database error!")), 500
 
     return Response(
@@ -504,6 +514,8 @@ def get_results_json():
     if not result_id:
         return jsonify(structure(status="error", msg=_("invalid_scan_id"))), 400
     scan_details = session.query(Report).filter(Report.id == result_id).first()
+    if not scan_details:
+        return jsonify(structure(status="error", msg=_("no_scan_data_found"))), 404
     json_object = json.dumps(get_logs_by_scan_id(scan_details.scan_unique_id))
     filename = ".".join(scan_details.report_path_filename.split(".")[:-1])[1:] + ".json"
     return Response(
@@ -527,6 +539,8 @@ def get_results_csv():  # todo: need to fix time format
     if not result_id:
         return jsonify(structure(status="error", msg=_("invalid_scan_id"))), 400
     scan_details = session.query(Report).filter(Report.id == result_id).first()
+    if not scan_details:
+        return jsonify(structure(status="error", msg=_("no_scan_data_found"))), 404
     data = get_logs_by_scan_id(scan_details.scan_unique_id)
     if not data:
         return jsonify(structure(status="error", msg=_("no_scan_data_found"))), 404
@@ -558,7 +572,13 @@ def get_last_host_logs():  # need to check
     page = get_value(flask_request, "page")
     if not page:
         page = 1
-    return jsonify(last_host_logs(int(page))), 200
+    try:
+        page_num = int(page)
+        if page_num < 1:
+            page_num = 1
+    except (ValueError, TypeError):
+        return jsonify(structure(status="error", msg="Invalid page number")), 400
+    return jsonify(last_host_logs(page_num)), 200
 
 
 @app.route("/logs/get_html", methods=["GET"])

--- a/tests/unit/api/test_engine.py
+++ b/tests/unit/api/test_engine.py
@@ -51,3 +51,59 @@ def test_get_logs_csv_empty_data(mock_logs_to_report_json, client):
     assert response.status_code == 404
     assert response.json["status"] == "error"
     assert response.json["msg"] == "No scan data found"
+
+
+@patch("nettacker.api.engine.create_connection")
+def test_get_results_json_nonexistent_scan(mock_create_connection, client):
+    """A nonexistent scan ID in /results/get_json must return 404."""
+    session = MagicMock()
+    session.query.return_value.filter.return_value.first.return_value = None
+    mock_create_connection.return_value = session
+
+    response = client.get(f"/results/get_json?id=9999&key={API_KEY}")
+
+    assert response.status_code == 404
+    assert response.json["status"] == "error"
+    assert response.json["msg"] == "No scan data found"
+
+
+@patch("nettacker.api.engine.create_connection")
+def test_get_results_csv_nonexistent_scan(mock_create_connection, client):
+    """A nonexistent scan ID in /results/get_csv must return 404."""
+    session = MagicMock()
+    session.query.return_value.filter.return_value.first.return_value = None
+    mock_create_connection.return_value = session
+
+    response = client.get(f"/results/get_csv?id=9999&key={API_KEY}")
+
+    assert response.status_code == 404
+    assert response.json["status"] == "error"
+    assert response.json["msg"] == "No scan data found"
+
+
+@patch("nettacker.api.engine.get_scan_result", return_value=None)
+def test_get_result_content_not_found(mock_get_scan_result, client):
+    """A nonexistent scan ID in /results/get must return 404."""
+    response = client.get(f"/results/get?id=9999&key={API_KEY}")
+
+    assert response.status_code == 404
+    assert response.json["status"] == "error"
+    assert response.json["msg"] == "No scan data found"
+
+
+def test_get_last_host_logs_invalid_page(client):
+    """Invalid page parameter in /logs/get_list must return 400 Bad Request."""
+    response = client.get(f"/logs/get_list?page=invalid&key={API_KEY}")
+
+    assert response.status_code == 400
+    assert response.json["status"] == "error"
+    assert response.json["msg"] == "Invalid page number"
+
+
+def test_select_reports_invalid_page(client):
+    """Invalid page parameter in /results/get_list must return 400 Bad Request."""
+    response = client.get(f"/results/get_list?page=invalid&key={API_KEY}")
+
+    assert response.status_code == 400
+    assert response.json["status"] == "error"
+    assert response.json["msg"] == "Invalid page number"


### PR DESCRIPTION
## Summary
This PR addresses uncaught exceptions and silent masking in `nettacker/api/engine.py`:
- In `/results/get_json` and `/results/get_csv`, gracefully checks if `scan_details` is found before referencing `scan_unique_id`, returning a clean `404` (`no_scan_data_found`) instead of crashing with 500.
- In `/results/get`, verifies `get_scan_result` returns valid content, logs exceptions with context, and returns `404` when the scan ID is not found.
- In `/logs/get_list` and `/results/get_list`, safely validates and coerces the `page` parameter to positive integers, returning `400` on invalid non-numeric inputs.

Closes #1713

## Testing
- Added unit tests in `tests/unit/api/test_engine.py` covering nonexistent scans (404), missing scan results (404), and invalid pagination parameters (400).
- Ran unit test suite: all 20 tests pass.