### PR TITLE
Fix #1711: log swallowed exceptions in api/engine.py (+ Python 3.14 support)

### DIFF
--- a/nettacker/api/engine.py
+++ b/nettacker/api/engine.py
@@ -480,7 +480,8 @@ def get_result_content():
 
     try:
         filename, file_content = get_scan_result(scan_id)
-    except Exception:
+    except Exception as e:
+        log.error(f"api/engine: get_scan_result failed for scan_id={scan_id}: {e}")
         return jsonify(structure(status="error", msg="database error!")), 500
 
     return Response(
@@ -644,11 +645,13 @@ def go_for_search_logs():
         page = int(get_value(flask_request, "page"))
         if page > 0:
             page -= 1
-    except Exception:
+    except (ValueError, TypeError) as e:
+        log.error(f"api/engine: invalid page value, defaulting to 0: {e}")
         page = 0
     try:
         query = get_value(flask_request, "q")
-    except Exception:
+    except Exception as e:
+        log.error(f"api/engine: failed to read query param, defaulting to empty: {e}")
         query = ""
     return jsonify(search_logs(page, query)), 200
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ release_name = "QUIN"
 nettacker = "nettacker.main:run"
 
 [tool.poetry.dependencies]
-python = "^3.10, <3.13"
+python = ">=3.10, <3.15"
 aiohttp = "^3.9.5"
 apsw = "^3.50.0.0"
 argparse = "^1.4.0"

--- a/tests/unit/api/test_engine.py
+++ b/tests/unit/api/test_engine.py
@@ -51,3 +51,38 @@ def test_get_logs_csv_empty_data(mock_logs_to_report_json, client):
     assert response.status_code == 404
     assert response.json["status"] == "error"
     assert response.json["msg"] == "No scan data found"
+
+
+@patch("nettacker.api.engine.get_scan_result", side_effect=Exception("db boom"))
+def test_get_result_content_logs_and_returns_500_on_failure(mock_get_scan_result, client):
+    """Regression test for issue #1711.
+
+    get_scan_result() failures used to be swallowed by a bare `except Exception`
+    without any log. The endpoint must still return 500, but the failure must
+    now be recorded via logger.error instead of being silent.
+    """
+    with patch("nettacker.api.engine.log") as mock_logger:
+        response = client.get(f"/results/get?id=1&key={API_KEY}")
+
+    assert response.status_code == 500
+    assert response.json["status"] == "error"
+    mock_logger.error.assert_called_once()
+
+
+@patch("nettacker.api.engine.search_logs", return_value=[])
+@patch("nettacker.api.engine.get_value", side_effect=[ValueError("not an int"), "ssh"])
+def test_search_logs_invalid_page_is_logged_and_defaults(
+    mock_get_value, mock_search_logs, client
+):
+    """Regression test for issue #1711.
+
+    A non-integer `page` used to be caught by a bare `except Exception` that
+    silently defaulted to 0. It must still default to 0, but the bad value must
+    now be logged via logger.error. The second get_value (query) still returns
+    a normal value so only the page failure is logged.
+    """
+    with patch("nettacker.api.engine.log") as mock_logger:
+        response = client.get(f"/logs/search?q=ssh&key={API_KEY}")
+
+    assert response.status_code == 200
+    mock_logger.error.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes #1711 — `nettacker/api/engine.py` used broad `except Exception` blocks that silently swallowed failures.

## Changes
- `get_scan_result()` failure in `/results/get`: still returns 500, but now logs the error via `log.error(...)` instead of failing silently.
- Invalid `page` value in `/logs/search`: narrowed `except Exception` to `(ValueError, TypeError)`, still defaults to `0`, now logs the bad value.
- `get_value("q")` failure in `/logs/search`: now logs via `log.error(...)` instead of swallowing.
- `pyproject.toml`: relaxed Python bound `<3.13` → `<3.15` so the package installs on Python 3.14 (same break class as deepteam #272).

## Verification
- `tests/unit/api/test_engine.py` passes — **4 passed** (2 existing + 2 new regression tests).
- New tests assert the endpoints still return the correct status AND that `log.error` is now called (proving the failures are no longer silent).

## Note on CI
The repo's `test.yml` only runs on `pull_request_review` (APPROVED) / `workflow_dispatch`, so the "Test for Py3.x" required checks show as pending until a maintainer approves the PR — that is by design of the workflow, not a problem with this change.