### PR TITLE
Fix test isolation breaking HTML report tests

### DIFF
--- a/nettacker/lib/html_log/log_data.py
+++ b/nettacker/lib/html_log/log_data.py
@@ -1,7 +1,30 @@
 from nettacker.config import Config
 
-css_1 = open(Config.path.web_static_dir / "report/html_table.css").read()
-json_parse_js = open(Config.path.web_static_dir / "report/json_parse.js").read()
-table_end = open(Config.path.web_static_dir / "report/table_end.html").read()
-table_items = open(Config.path.web_static_dir / "report/table_items.html").read()
-table_title = open(Config.path.web_static_dir / "report/table_title.html").read()
+_TEMPLATE_FILES = {
+    "css_1": "report/html_table.css",
+    "json_parse_js": "report/json_parse.js",
+    "table_end": "report/table_end.html",
+    "table_items": "report/table_items.html",
+    "table_title": "report/table_title.html",
+}
+
+
+def __getattr__(name):
+    """Read report templates on first access instead of at import time.
+
+    Reading at import made import order significant: any code that changed
+    Config.path.web_static_dir before this module was first imported caused
+    the import itself to fail.
+    """
+    try:
+        relative_path = _TEMPLATE_FILES[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+    value = (Config.path.web_static_dir / relative_path).read_text()
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted([*globals(), *_TEMPLATE_FILES])

--- a/nettacker/lib/html_log/log_data.py
+++ b/nettacker/lib/html_log/log_data.py
@@ -8,6 +8,22 @@ _TEMPLATE_FILES = {
     "table_title": "report/table_title.html",
 }
 
+__all__ = [
+    "css_1",
+    "json_parse_js",
+    "table_end",
+    "table_items",
+    "table_title",
+]
+
+# Declared for static analysis and wildcard imports. These are annotations
+# only, so the names stay unbound and __getattr__ below still resolves them.
+css_1: str
+json_parse_js: str
+table_end: str
+table_items: str
+table_title: str
+
 
 def __getattr__(name):
     """Read report templates on first access instead of at import time.
@@ -27,4 +43,4 @@ def __getattr__(name):
 
 
 def __dir__():
-    return sorted([*globals(), *_TEMPLATE_FILES])
+    return sorted({*globals(), *_TEMPLATE_FILES})

--- a/tests/unit/api/test_core.py
+++ b/tests/unit/api/test_core.py
@@ -18,6 +18,19 @@ from nettacker.api.core import (
 from nettacker.config import Config
 
 
+@pytest.fixture(autouse=True)
+def restore_web_static_dir():
+    """Restore Config.path.web_static_dir after each test in this module.
+
+    Several tests below assign to it directly. Without this the last value
+    assigned leaks into every later test in the same process, which broke
+    nettacker.lib.html_log.log_data (see #1721).
+    """
+    original = Config.path.web_static_dir
+    yield
+    Config.path.web_static_dir = original
+
+
 @pytest.fixture
 def app():
     app = Flask(__name__)

--- a/tests/unit/lib/html_log/test_log_data.py
+++ b/tests/unit/lib/html_log/test_log_data.py
@@ -1,0 +1,49 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from nettacker.config import Config
+
+MODULE = "nettacker.lib.html_log.log_data"
+
+
+def _reimport(monkeypatch, static_dir):
+    monkeypatch.setattr(Config.path, "web_static_dir", static_dir)
+    monkeypatch.delitem(sys.modules, MODULE, raising=False)
+    return importlib.import_module(MODULE)
+
+
+def test_import_does_not_read_files(monkeypatch):
+    """Importing must not touch the filesystem.
+
+    Reading templates at import time made import order significant: any
+    earlier code that changed web_static_dir broke this import (#1721).
+    """
+    _reimport(monkeypatch, Path("/nonexistent/nettacker-1721"))
+
+
+def test_templates_are_read_from_current_static_dir(monkeypatch, tmp_path):
+    report_dir = tmp_path / "report"
+    report_dir.mkdir()
+    (report_dir / "html_table.css").write_text("/*css*/")
+    (report_dir / "json_parse.js").write_text("/*js*/")
+    (report_dir / "table_end.html").write_text("</table>")
+    (report_dir / "table_items.html").write_text("<tr></tr>")
+    (report_dir / "table_title.html").write_text("<table>")
+
+    log_data = _reimport(monkeypatch, tmp_path)
+
+    assert log_data.css_1 == "/*css*/"
+    assert log_data.json_parse_js == "/*js*/"
+    assert log_data.table_end == "</table>"
+    assert log_data.table_items == "<tr></tr>"
+    assert log_data.table_title == "<table>"
+
+
+def test_unknown_attribute_raises_attribute_error(monkeypatch, tmp_path):
+    log_data = _reimport(monkeypatch, tmp_path)
+
+    with pytest.raises(AttributeError):
+        _ = log_data.not_a_template

--- a/tests/unit/lib/html_log/test_log_data.py
+++ b/tests/unit/lib/html_log/test_log_data.py
@@ -6,7 +6,35 @@ import pytest
 
 from nettacker.config import Config
 
-MODULE = "nettacker.lib.html_log.log_data"
+PARENT = "nettacker.lib.html_log"
+MODULE = f"{PARENT}.log_data"
+
+
+@pytest.fixture(autouse=True)
+def restore_log_data_module():
+    """Undo the re-imports done below.
+
+    importlib rebinds the attribute on the parent package as well as the
+    sys.modules entry, so both are restored. Otherwise a later
+    "from nettacker.lib.html_log import log_data" picks up a module holding
+    templates cached from a temporary directory.
+    """
+    parent = importlib.import_module(PARENT)
+    had_attribute = hasattr(parent, "log_data")
+    original_attribute = getattr(parent, "log_data", None)
+    original_module = sys.modules.get(MODULE)
+
+    yield
+
+    if original_module is None:
+        sys.modules.pop(MODULE, None)
+    else:
+        sys.modules[MODULE] = original_module
+
+    if had_attribute:
+        parent.log_data = original_attribute
+    elif hasattr(parent, "log_data"):
+        del parent.log_data
 
 
 def _reimport(monkeypatch, static_dir):


### PR DESCRIPTION
Fixes #1721

`nettacker/lib/html_log/log_data.py` read five report templates at module import. That made import order significant. Four tests in `tests/unit/api/test_core.py` (lines 50, 57, 65, 72) assign `Config.path.web_static_dir` directly and never restore it, so a later import of `log_data` resolved against the leaked `/safe/dir` value and raised `FileNotFoundError`.

CI does not see this because the default `addopts` run the suite under xdist with `--dist loadscope`, which puts the api and database modules in separate worker processes. The leaked global never crosses between them. The failure only appears in a single-process run, which is how @einsibjarni hit it while packaging Nettacker for FreeBSD ports.

## Changes

`nettacker/lib/html_log/log_data.py` loads templates on first access through a module-level `__getattr__` and caches them, instead of reading them at import. `__all__` lists the five template names so wildcard imports still work, and the names are declared as annotations so static analysis can resolve them without binding them. Attribute access and `mock.patch` are unchanged, so `tests/unit/database/test_db.py:1081` still works.

`tests/unit/api/test_core.py` gains one autouse fixture that saves and restores `web_static_dir`. One fixture covers all four assignment sites.

`tests/unit/lib/html_log/test_log_data.py` is new. It checks that importing the module touches no files, that templates load from the current static directory, and that an unknown attribute raises `AttributeError`. Its fixture restores both the `sys.modules` entry and the parent package attribute, since `importlib` rebinds both.

## Verification

Python 3.12.13, `pytest tests/unit -o addopts=`

On master, before this branch:

    FAILED tests/unit/core/lib/test_socket.py::TestSocketMethod::test_create_tcp_socket
    FAILED tests/unit/core/lib/test_ssl.py::TestSslMethod::test_create_tcp_socket
    FAILED tests/unit/database/test_db.py::TestDatabase::test_logs_to_report_html_sqlite
    FAILED tests/unit/database/test_db.py::TestDatabase::test_logs_to_report_html_sqlalchemy
    4 failed, 338 passed, 6 skipped, 2 xfailed

On this branch, rebased onto current master:

    FAILED tests/unit/core/lib/test_socket.py::TestSocketMethod::test_create_tcp_socket
    FAILED tests/unit/core/lib/test_ssl.py::TestSslMethod::test_create_tcp_socket
    2 failed, 357 passed, 6 skipped, 2 xfailed

The passed totals differ because the rebase picked up #1707, which added tests.

Running with the default addopts gives the same 2 failed, 357 passed, so the result no longer depends on how the suite is invoked.

The two remaining failures are the `ssl.wrap_socket` tests, which #1676 covers.

`ruff check` and `ruff format --diff` are clean on the changed files. There is a pre-existing B017 in `tests/unit/api/test_core.py:98` that I left alone since it is unrelated to this fix.

This re-enables two of the three tests @einsibjarni disabled in the FreeBSD port. `test_create_tcp_socket` still depends on #1676.