### PR TITLE
test(core): add unit tests for POP3 library and engine

### DIFF
--- a/tests/unit/core/lib/test_pop3.py
+++ b/tests/unit/core/lib/test_pop3.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, patch
+import pytest
+
+from nettacker.core.lib.pop3 import Pop3Engine, Pop3Library
+
+HOST = "10.0.0.1"
+PORT = 110
+USER = "testuser"
+PASS = "testpass"
+TIMEOUT = 5
+
+
+@pytest.fixture
+def pop3_client_mocks():
+    with patch.object(Pop3Library, "client") as mock_pop3_class:
+        mock_connection = MagicMock()
+        mock_pop3_class.return_value = mock_connection
+        yield mock_pop3_class, mock_connection
+
+
+class TestPop3Engine:
+    def test_engine_has_correct_library(self):
+        assert Pop3Engine.library == Pop3Library
+
+    def test_engine_instantiates(self):
+        engine = Pop3Engine()
+        assert engine is not None
+
+
+class TestPop3Library:
+    def test_successful_login_returns_dict(self, pop3_client_mocks):
+        _, _ = pop3_client_mocks
+        lib = Pop3Library()
+        result = lib.brute_force(HOST, PORT, USER, PASS, TIMEOUT)
+
+        assert result == {
+            "host": HOST,
+            "port": PORT,
+            "username": USER,
+            "password": PASS,
+        }
+
+    def test_successful_login_calls_user_pass_quit(self, pop3_client_mocks):
+        _, mock_connection = pop3_client_mocks
+        lib = Pop3Library()
+        lib.brute_force(HOST, PORT, USER, PASS, TIMEOUT)
+
+        mock_connection.user.assert_called_once_with(USER)
+        mock_connection.pass_.assert_called_once_with(PASS)
+        mock_connection.quit.assert_called_once()


### PR DESCRIPTION
<!--
  Thanks for contributing to OWASP Nettacker! 
  Please read and follow the instructions!
  Please DO NOT REMOVE THIS PR TEMPLATE AND THE PR CHECKLIST AT THE BOTTOM!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to a new or existing issue.
  Remember to digitally sign your commits, run tests, attach screenshot/video evidence, add documentation
  Check and follow the contribution guidelines here: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines
  We use CodeRabbit.AI to perform the first round of PR reviews
  PRs failing to comply with the contribution guidelines and PR checks in this template may be auto-closed without a human maintainer review
-->

Fixes #1736

Currently, `nettacker/core/lib/pop3.py` has 0% test coverage. 

This PR adds a dedicated unit test suite in `tests/unit/core/lib/test_pop3.py` to test `Pop3Engine` initialization and `Pop3Library.brute_force()` execution using mock POP3 objects.

This brings `nettacker/core/lib/pop3.py` test coverage from 0% to 100%.



## Type of change

<!--
  Type of change you want to introduce. 
  Select one (1) option only.
  If your PR seems to fit multiple options, it likely should be split into multiple PRs.
-->

- [ ] New core framework functionality
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] Code refactoring without any functionality changes
- [ ] New or existing module/payload change
- [ ] Documentation/localization improvement
- [x] Test coverage improvement
- [ ] Dependency upgrade
- [ ] Other improvement (best practice, cleanup, optimization, etc)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after the PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] I've **digitally signed** all my commits in this PR
- [ ] I've run `make pre-commit` and confirm it didn't generate any warnings/changes
- [x] I've run `make test` and I confirm all tests passed locally
- [ ] I've added/updated any relevant documentation in the `docs/` folder 
- [x] I've linked this PR with an open issue
- [x] I've tested and verified that my code works as intended and resolves the issue as described
- [ ] I've attached screenshots demonstrating that my code works as intended (if applicable)
- [x] I've checked all other open PRs to avoid submitting duplicate work
- [x] I confirm that the code and comments in this PR are not direct unreviewed outputs of AI
- [x] I confirm that I am the Sole Responsible Author for every line of code, comment, and design decision

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://nettacker.readthedocs.io/en/latest/Developers/#contribution-guidelines
